### PR TITLE
Implement user-supplied ignore list of modules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           ubuntu-version: 'latest'
           macos-version: 'latest'
           version: 0.1.7.1
-  tests:
+  builds:
     name: ${{ matrix.ghc }} on ${{ matrix.os }}
     needs: generate-matrix
     runs-on: ${{ matrix.os }}
@@ -61,15 +61,6 @@ jobs:
           bin=$(cabal -v0 --project-file=cabal.static.project list-bin print-api)
           mkdir distribution
           cp ${bin} distribution/print-api
-
-      - name: Test
-        run: cabal test --project-file=cabal.release.project --test-options "--xml=report.xml" all
-
-      - name: Publish Test Report
-        uses: mikepenz/action-junit-report@v4
-        if: success() || failure() # always run even if the previous step fails
-        with:
-          report_paths: "report.xml"
 
       - name: File type
         run: file distribution/print-api
@@ -168,7 +159,7 @@ jobs:
   prerelease-head:
     name: Create a GitHub prerelease with the binary artifacts
     runs-on: ubuntu-latest
-    needs: ['tests', 'build-alpine']
+    needs: ['builds', 'build-alpine']
 
     steps:
     - uses: actions/download-artifact@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,7 @@ jobs:
           cp ${bin} distribution/print-api
 
       - name: Test
-        run: cabal test --project-file=cabal.static.project --test-options "--xml=report.xml" all
+        run: cabal test --project-file=cabal.static.project --test-options "--xml=../print-api/report.xml" all
 
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,15 @@ jobs:
           mkdir distribution
           cp ${bin} distribution/print-api
 
+      - name: Test
+        run: cabal test --project-file=cabal.release.project --test-options "--xml=report.xml" all
+
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@v4
+        if: success() || failure() # always run even if the previous step fails
+        with:
+          report_paths: "report.xml"
+
       - name: File type
         run: file distribution/print-api
 
@@ -122,14 +131,20 @@ jobs:
       - name: Build
         run: cabal build --project-file=cabal.static.project
 
-      - name: Test
-        run: cabal test --project-file=cabal.static.project all
-
       - name: Install
         run: |
           bin=$(cabal -v0 --project-file=cabal.static.project list-bin print-api)
           mkdir distribution
           cp ${bin} distribution/print-api
+
+      - name: Test
+        run: cabal test --project-file=cabal.static.project --test-options "--xml=report.xml" all
+
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@v4
+        if: success() || failure() # always run even if the previous step fails
+        with:
+          report_paths: "report.xml"
 
       - name: File type
         run: file distribution/print-api

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ tags.mtime
 .hpc
 *.tix
 *.local
+servant-client-actual-api.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 0.1.1.0
+
+* Add support for user-supplied ignore lists of modules ([#18](https://github.com/Kleidukos/print-api/pull/18))

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ deps: ## Install the dependencies of the backend
 	@cabal build --only-dependencies
 
 build: ## Build the project in fast mode
-	@cabal build
+	@cabal build -j
 
 clean: ## Remove compilation artifacts
 	@cabal clean
@@ -11,7 +11,7 @@ repl: ## Start a REPL
 	@cabal repl
 
 test: ## Run the test suite
-	@cabal test
+	@cabal test -j
 
 lint: ## Run the code linter (HLint)
 	@find app src compat -name "*.hs" | xargs -P $(PROCS) -I {} hlint --refactor-options="-i" --refactor {}

--- a/cabal.project
+++ b/cabal.project
@@ -1,1 +1,10 @@
 packages: ./
+
+tests: True
+
+allow-newer: tasty-test-reporter:mtl, tasty-test-reporter:ansi-terminal, tasty-test-reporter:text, tasty-test-reporter:tasty
+
+source-repository-package
+  type: git
+  location: https://github.com/goodlyrottenapple/tasty-test-reporter 
+  tag: b704130

--- a/cabal.project
+++ b/cabal.project
@@ -2,7 +2,20 @@ packages: ./
 
 tests: True
 
-allow-newer: tasty-test-reporter:mtl, tasty-test-reporter:ansi-terminal, tasty-test-reporter:text, tasty-test-reporter:tasty
+allow-newer:
+    tasty-test-reporter:mtl
+  , tasty-test-reporter:ansi-terminal
+  , tasty-test-reporter:text
+  , tasty-test-reporter:tasty
+  , tasty-test-reporter:containers
+  , tasty-test-reporter:filepath
+  , tasty-test-reporter:base
+
+allow-newer:
+  , tasty-coverage:text
+  , tasty-coverage:containers
+  , tasty-coverage:filepath
+  , tasty-coverage:base
 
 source-repository-package
   type: git

--- a/print-api.cabal
+++ b/print-api.cabal
@@ -68,6 +68,7 @@ library
     , base
     , bytestring
     , extra
+    , filepath
     , ghc
     , ghc-boot
     , ghc-paths
@@ -76,11 +77,11 @@ library
     , typed-process
 
 executable print-api
-  import:           extensions
-  import:           ghc-options
-  import:           rts-options
-  hs-source-dirs:   app
-  main-is:          Main.hs
+  import:         extensions
+  import:         ghc-options
+  import:         rts-options
+  hs-source-dirs: app
+  main-is:        Main.hs
   build-depends:
     , base
     , ghc
@@ -88,4 +89,28 @@ executable print-api
     , optparse-applicative
     , print-api
 
-  default-language: Haskell2010
+test-suite print-api-test
+  import:         extensions
+  import:         ghc-options
+  import:         rts-options
+  type:           exitcode-stdio-1.0
+  hs-source-dirs: test
+  main-is:        Main.hs
+  other-modules:
+    IgnoreList
+    Utils
+
+  build-depends:
+    , base
+    , bytestring
+    , directory
+    , extra
+    , filepath
+    , ghc
+    , print-api
+    , tasty
+    , tasty-coverage
+    , tasty-golden
+    , tasty-hunit
+    , tasty-test-reporter
+    , typed-process

--- a/src/PrintApi/CLI/Cmd/Dump.hs
+++ b/src/PrintApi/CLI/Cmd/Dump.hs
@@ -3,6 +3,7 @@ module PrintApi.CLI.Cmd.Dump where
 import Control.Monad.IO.Class
 import Data.Function (on)
 import Data.List qualified as List
+import Data.List.Extra qualified as List
 import GHC
 import GHC.Compat
 import GHC.Core.Class (classMinimalDef)
@@ -74,7 +75,7 @@ computePackageAPI root userIgnoredModules packageName = runGhc (Just root) $ do
   insts_doc <- reportInstances
 
   name_ppr_ctx <- GHC.getNamePprCtx
-  pure $ showSDocForUser dflags unit_state name_ppr_ctx (vcat [decls_doc, insts_doc])
+  pure $ List.trim $ showSDocForUser dflags unit_state name_ppr_ctx (vcat [decls_doc, insts_doc])
 
 ignoredTyThing :: TyThing -> Bool
 ignoredTyThing _ = False

--- a/src/PrintApi/CLI/Types.hs
+++ b/src/PrintApi/CLI/Types.hs
@@ -4,13 +4,17 @@ import Data.ByteString.Lazy.Char8 qualified as ByteString
 import Data.List.Extra qualified as List
 import Data.Version (showVersion)
 import Options.Applicative
-import Paths_print_api (version)
-import PrintApi.CLI.Cmd.Dump (run)
+import System.OsPath (OsPath)
+import System.OsPath qualified as OsPath
 import System.Process.Typed (ExitCode (..))
 import System.Process.Typed qualified as Process
 
+import Paths_print_api (version)
+import PrintApi.CLI.Cmd.Dump (run)
+
 data Options = Options
   { packageName :: String
+  , moduleIgnoreList :: Maybe OsPath
   }
   deriving stock (Show, Eq)
 
@@ -20,15 +24,17 @@ parseOptions =
     <$> option
       str
       (long "package-name" <> short 'p' <> metavar "PACKAGE NAME" <> help "Name of the package")
+    <*> optional
+      (option osPathOption (long "modules-ignore-list" <> metavar "FILE" <> help "Read the file for a list of ignored modules (one per line)"))
 
 runOptions
   :: Options
   -> IO ()
-runOptions (Options packageName) = do
+runOptions (Options packageName mModuleIgnoreList) = do
   (exitCode, stdOut, stdErr) <- Process.readProcess $ Process.shell "cabal exec -v0 -- ghc --print-libdir"
   case exitCode of
     ExitSuccess ->
-      run (List.trimEnd $ ByteString.unpack stdOut) packageName
+      run (List.trimEnd $ ByteString.unpack stdOut) mModuleIgnoreList packageName
     ExitFailure int -> do
       putStrLn $ "`cabal exec -v0 -- ghc --print-libdir` exited with error code " <> show int
       error $ ByteString.unpack stdErr
@@ -41,3 +47,6 @@ withInfo opts desc =
         <*> opts
     )
     $ progDesc desc
+
+osPathOption :: ReadM OsPath
+osPathOption = maybeReader OsPath.encodeUtf

--- a/src/PrintApi/IgnoredDeclarations.hs
+++ b/src/PrintApi/IgnoredDeclarations.hs
@@ -9,6 +9,7 @@ module PrintApi.IgnoredDeclarations
   ) where
 
 import Data.List (isPrefixOf)
+import Data.List qualified as List
 import GHC (ModuleInfo, modInfoExports)
 import GHC.Core.InstEnv (ClsInst, instanceHead)
 import GHC.Core.TyCon (TyCon)
@@ -96,7 +97,7 @@ ignoredType = any ignoredTyCon . nonDetEltsUniqSet . tyConsOfType
 
 ignoredModules :: [ModuleName]
 ignoredModules =
-  map
+  List.map
     mkModuleName
     (unstableModules ++ platformDependentModules)
   where

--- a/test/IgnoreList.hs
+++ b/test/IgnoreList.hs
@@ -37,7 +37,7 @@ generateServantClientAPIWithIgnoreList = do
   assertExitSuccess "`cabal exec -v0 -- ghc --print-libdir`" exitCode
   assertExitSuccess "Fetch the archive of servant-client" =<< Process.runProcess (Process.shell "cabal get servant-client-0.20 --destdir=../")
   liftIO $ Directory.setCurrentDirectory "../servant-client-0.20"
-  let buildServantClient = Process.shell "cabal build --allow-newer --write-ghc-environment-files=always"
+  let buildServantClient = Process.shell "cabal build -j --allow-newer --write-ghc-environment-files=always"
   assertExitSuccess "Build servant-client" =<< Process.runProcess buildServantClient
   ignoreListPath <- liftIO $ OsPath.makeAbsolute [osp|../print-api/test/golden/servant-client-ignore-list.txt|]
   ignoreListFilePath <- liftIO $ OsPath.decodeUtf ignoreListPath

--- a/test/IgnoreList.hs
+++ b/test/IgnoreList.hs
@@ -1,0 +1,49 @@
+{-# LANGUAGE QuasiQuotes #-}
+module IgnoreList where
+
+import Control.Monad.IO.Class
+import Data.ByteString.Lazy (LazyByteString)
+import Data.ByteString.Lazy.Char8 qualified as C8
+import Data.List.Extra qualified as List
+import Language.Haskell.Syntax.Module.Name (mkModuleName)
+import System.Process.Typed qualified as Process
+import Test.Tasty
+import System.OsPath
+import Test.Tasty.Golden
+import Utils
+import qualified Data.ByteString.Lazy as ByteString
+import qualified System.Directory as Directory 
+
+import qualified PrintApi.CLI.Cmd.Dump as Dump
+import qualified System.Directory.OsPath as OsPath
+import qualified System.IO as System
+import qualified System.OsPath as OsPath
+
+diffCmd :: String -> String -> [String]
+diffCmd ref new = ["diff", "-u", ref, new]
+
+spec :: TestTree
+spec = testGroup "Ignore list"
+  [ goldenVsStringDiff
+        "User-supplied ignore list"
+        diffCmd
+        "test/golden/servant-client-expected-api.txt"
+        generateServantClientAPIWithIgnoreList
+  ]
+
+generateServantClientAPIWithIgnoreList :: (MonadIO m) => m LazyByteString
+generateServantClientAPIWithIgnoreList = do
+  (exitCode, stdOut, _stdErr) <- Process.readProcess $ Process.shell "cabal exec -v0 -- ghc --print-libdir"
+  assertExitSuccess "`cabal exec -v0 -- ghc --print-libdir`" exitCode
+  assertExitSuccess "Fetch the archive of servant-client" =<< Process.runProcess (Process.shell "cabal get servant-client-0.20 --destdir=../")
+  liftIO $ Directory.setCurrentDirectory "../servant-client-0.20"
+  let buildServantClient = Process.shell "cabal build --write-ghc-environment-files=always"
+  assertExitSuccess "Build servant-client" =<< Process.runProcess buildServantClient
+  ignoreListPath <- liftIO $ OsPath.makeAbsolute [osp|../print-api/test/golden/servant-client-ignore-list.txt|]
+  ignoreListFilePath <- liftIO $ OsPath.decodeUtf ignoreListPath
+  modules <- lines <$> liftIO (System.readFile ignoreListFilePath)
+  let ignoredModules = List.map mkModuleName modules
+  actualAPI <- liftIO $ Dump.computePackageAPI (List.trimEnd $ C8.unpack stdOut) ignoredModules "servant-client"
+  actualApiPath <- liftIO $ Directory.makeAbsolute "../print-api/test/golden/servant-client-actual-api.txt"
+  liftIO $ System.writeFile actualApiPath actualAPI
+  liftIO $ ByteString.readFile actualApiPath

--- a/test/IgnoreList.hs
+++ b/test/IgnoreList.hs
@@ -37,7 +37,7 @@ generateServantClientAPIWithIgnoreList = do
   assertExitSuccess "`cabal exec -v0 -- ghc --print-libdir`" exitCode
   assertExitSuccess "Fetch the archive of servant-client" =<< Process.runProcess (Process.shell "cabal get servant-client-0.20 --destdir=../")
   liftIO $ Directory.setCurrentDirectory "../servant-client-0.20"
-  let buildServantClient = Process.shell "cabal build --write-ghc-environment-files=always"
+  let buildServantClient = Process.shell "cabal build --allow-newer --write-ghc-environment-files=always"
   assertExitSuccess "Build servant-client" =<< Process.runProcess buildServantClient
   ignoreListPath <- liftIO $ OsPath.makeAbsolute [osp|../print-api/test/golden/servant-client-ignore-list.txt|]
   ignoreListFilePath <- liftIO $ OsPath.decodeUtf ignoreListPath

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,0 +1,20 @@
+module Main (main) where
+
+import System.IO
+import Test.Tasty
+import Test.Tasty.Runners.Reporter qualified as Reporter
+
+import IgnoreList qualified
+
+main :: IO ()
+main = do
+  hSetBuffering stdout LineBuffering
+  defaultMainWithIngredients
+    [Reporter.ingredient]
+    $ testGroup
+      "print-api tests"
+      specs
+
+specs :: [TestTree]
+specs =
+  [ IgnoreList.spec ]

--- a/test/Utils.hs
+++ b/test/Utils.hs
@@ -1,0 +1,9 @@
+module Utils where
+
+import Test.Tasty.HUnit
+import System.Process.Typed
+import Control.Monad.IO.Class
+
+assertExitSuccess :: (MonadIO m) => String -> ExitCode -> m ()
+assertExitSuccess _ ExitSuccess = pure ()
+assertExitSuccess desc (ExitFailure n) = liftIO $ assertFailure $ desc <> ": Unexpected process failure (exit code " <> show n <> ")"

--- a/test/golden/servant-client-actual-api.txt
+++ b/test/golden/servant-client-actual-api.txt
@@ -1,0 +1,193 @@
+
+module Servant.Client where
+  (//) :: forall a b. a -> (a -> b) -> b
+  (/:) :: forall a b c. (a -> b -> c) -> b -> a -> c
+  type role AsClientT phantom
+  type AsClientT :: (* -> *) -> *
+  data AsClientT m
+  type BaseUrl :: *
+  data BaseUrl = BaseUrl {baseUrlScheme :: Scheme, baseUrlHost :: GHC.Base.String, baseUrlPort :: GHC.Types.Int, baseUrlPath :: GHC.Base.String}
+  type ClientEnv :: *
+  data ClientEnv = ClientEnv {manager :: http-client-0.7.17:Network.HTTP.Client.Types.Manager, baseUrl :: BaseUrl, cookieJar :: GHC.Maybe.Maybe (GHC.Conc.Sync.TVar http-client-0.7.17:Network.HTTP.Client.Types.CookieJar), makeClientRequest :: BaseUrl -> Servant.Client.Core.Request.Request -> GHC.Types.IO http-client-0.7.17:Network.HTTP.Client.Types.Request}
+  type ClientError :: *
+  data ClientError = FailureResponse (Servant.Client.Core.Request.RequestF () (BaseUrl, bytestring-0.11.5.3:Data.ByteString.Internal.Type.ByteString)) Response | DecodeFailure Data.Text.Internal.Text Response | UnsupportedContentType http-media-0.8.1.1:Network.HTTP.Media.MediaType.Internal.MediaType Response | InvalidContentTypeHeader Response | ConnectionError GHC.Exception.Type.SomeException
+  type role ClientM nominal
+  type ClientM :: * -> *
+  newtype ClientM a = Servant.Client.Internal.HttpClient.ClientM {Servant.Client.Internal.HttpClient.unClientM :: Control.Monad.Trans.Reader.ReaderT ClientEnv (Control.Monad.Trans.Except.ExceptT ClientError GHC.Types.IO) a}
+  type EmptyClient :: *
+  data EmptyClient = EmptyClient
+  type HasClient :: (* -> *) -> * -> Constraint
+  class Servant.Client.Core.RunClient.RunClient m => HasClient m api where
+    type Client :: (* -> *) -> * -> *
+    type family Client m api
+    clientWithRoute :: Data.Proxy.Proxy m -> Data.Proxy.Proxy api -> Servant.Client.Core.Request.Request -> Client m api
+    hoistClientMonad :: forall (mon :: * -> *) (mon' :: * -> *). Data.Proxy.Proxy m -> Data.Proxy.Proxy api -> (forall x. mon x -> mon' x) -> Client mon api -> Client mon' api
+    {-# MINIMAL clientWithRoute, hoistClientMonad #-}
+    {-# MINIMAL clientWithRoute, hoistClientMonad #-}
+  type InvalidBaseUrlException :: *
+  newtype InvalidBaseUrlException = Servant.Client.Core.BaseUrl.InvalidBaseUrlException GHC.Base.String
+  type Response :: *
+  type Response = ResponseF Data.ByteString.Lazy.Internal.ByteString
+  type ResponseF :: * -> *
+  data ResponseF a = Response {responseStatusCode :: Network.HTTP.Types.Status.Status, responseHeaders :: Data.Sequence.Internal.Seq Network.HTTP.Types.Header.Header, responseHttpVersion :: Network.HTTP.Types.Version.HttpVersion, responseBody :: a}
+  type Scheme :: *
+  data Scheme = Http | Https
+  type StreamingResponse :: *
+  type StreamingResponse = ResponseF (Servant.API.Stream.SourceIO bytestring-0.11.5.3:Data.ByteString.Internal.Type.ByteString)
+  client :: forall api. HasClient ClientM api => Data.Proxy.Proxy api -> Client ClientM api
+  defaultMakeClientRequest :: BaseUrl -> Servant.Client.Core.Request.Request -> GHC.Types.IO http-client-0.7.17:Network.HTTP.Client.Types.Request
+  foldMapUnion :: forall (c :: * -> Constraint) a (as :: [*]). Data.SOP.Constraint.All c as => Data.Proxy.Proxy c -> (forall x. c x => x -> a) -> Servant.API.UVerb.Union.Union as -> a
+  hoistClient :: forall api (m :: * -> *) (n :: * -> *). HasClient ClientM api => Data.Proxy.Proxy api -> (forall a. m a -> n a) -> Client m api -> Client n api
+  matchUnion :: forall a (as :: [*]). Servant.API.UVerb.Union.IsMember a as => Servant.API.UVerb.Union.Union as -> GHC.Maybe.Maybe a
+  mkClientEnv :: http-client-0.7.17:Network.HTTP.Client.Types.Manager -> BaseUrl -> ClientEnv
+  parseBaseUrl :: forall (m :: * -> *). Control.Monad.Catch.MonadThrow m => GHC.Base.String -> m BaseUrl
+  runClientM :: forall a. ClientM a -> ClientEnv -> GHC.Types.IO (Data.Either.Either ClientError a)
+  showBaseUrl :: BaseUrl -> GHC.Base.String
+
+module Servant.Client.Internal.HttpClient where
+
+-- ignored
+
+
+module Servant.Client.Internal.HttpClient.Streaming where
+
+-- ignored
+
+
+module Servant.Client.Streaming where
+  (//) :: forall a b. a -> (a -> b) -> b
+  (/:) :: forall a b c. (a -> b -> c) -> b -> a -> c
+  type role AsClientT phantom
+  type AsClientT :: (* -> *) -> *
+  data AsClientT m
+  type BaseUrl :: *
+  data BaseUrl = BaseUrl {baseUrlScheme :: Scheme, baseUrlHost :: GHC.Base.String, baseUrlPort :: GHC.Types.Int, baseUrlPath :: GHC.Base.String}
+  type ClientEnv :: *
+  data ClientEnv = ClientEnv {manager :: http-client-0.7.17:Network.HTTP.Client.Types.Manager, baseUrl :: BaseUrl, cookieJar :: GHC.Maybe.Maybe (GHC.Conc.Sync.TVar http-client-0.7.17:Network.HTTP.Client.Types.CookieJar), makeClientRequest :: BaseUrl -> Servant.Client.Core.Request.Request -> GHC.Types.IO http-client-0.7.17:Network.HTTP.Client.Types.Request}
+  type ClientError :: *
+  data ClientError = FailureResponse (Servant.Client.Core.Request.RequestF () (BaseUrl, bytestring-0.11.5.3:Data.ByteString.Internal.Type.ByteString)) Response | DecodeFailure Data.Text.Internal.Text Response | UnsupportedContentType http-media-0.8.1.1:Network.HTTP.Media.MediaType.Internal.MediaType Response | InvalidContentTypeHeader Response | ConnectionError GHC.Exception.Type.SomeException
+  type role ClientM nominal
+  type ClientM :: * -> *
+  newtype ClientM a = Servant.Client.Internal.HttpClient.Streaming.ClientM {Servant.Client.Internal.HttpClient.Streaming.unClientM :: Control.Monad.Trans.Reader.ReaderT ClientEnv (Control.Monad.Trans.Except.ExceptT ClientError (Control.Monad.Codensity.Codensity GHC.Types.IO)) a}
+  type EmptyClient :: *
+  data EmptyClient = EmptyClient
+  type HasClient :: (* -> *) -> * -> Constraint
+  class Servant.Client.Core.RunClient.RunClient m => HasClient m api where
+    type Client :: (* -> *) -> * -> *
+    type family Client m api
+    clientWithRoute :: Data.Proxy.Proxy m -> Data.Proxy.Proxy api -> Servant.Client.Core.Request.Request -> Client m api
+    hoistClientMonad :: forall (mon :: * -> *) (mon' :: * -> *). Data.Proxy.Proxy m -> Data.Proxy.Proxy api -> (forall x. mon x -> mon' x) -> Client mon api -> Client mon' api
+    {-# MINIMAL clientWithRoute, hoistClientMonad #-}
+    {-# MINIMAL clientWithRoute, hoistClientMonad #-}
+  type InvalidBaseUrlException :: *
+  newtype InvalidBaseUrlException = Servant.Client.Core.BaseUrl.InvalidBaseUrlException GHC.Base.String
+  type Response :: *
+  type Response = ResponseF Data.ByteString.Lazy.Internal.ByteString
+  type ResponseF :: * -> *
+  data ResponseF a = Response {responseStatusCode :: Network.HTTP.Types.Status.Status, responseHeaders :: Data.Sequence.Internal.Seq Network.HTTP.Types.Header.Header, responseHttpVersion :: Network.HTTP.Types.Version.HttpVersion, responseBody :: a}
+  type Scheme :: *
+  data Scheme = Http | Https
+  type StreamingResponse :: *
+  type StreamingResponse = ResponseF (Servant.API.Stream.SourceIO bytestring-0.11.5.3:Data.ByteString.Internal.Type.ByteString)
+  client :: forall api. HasClient ClientM api => Data.Proxy.Proxy api -> Client ClientM api
+  defaultMakeClientRequest :: BaseUrl -> Servant.Client.Core.Request.Request -> GHC.Types.IO http-client-0.7.17:Network.HTTP.Client.Types.Request
+  foldMapUnion :: forall (c :: * -> Constraint) a (as :: [*]). Data.SOP.Constraint.All c as => Data.Proxy.Proxy c -> (forall x. c x => x -> a) -> Servant.API.UVerb.Union.Union as -> a
+  hoistClient :: forall api (m :: * -> *) (n :: * -> *). HasClient ClientM api => Data.Proxy.Proxy api -> (forall a. m a -> n a) -> Client m api -> Client n api
+  matchUnion :: forall a (as :: [*]). Servant.API.UVerb.Union.IsMember a as => Servant.API.UVerb.Union.Union as -> GHC.Maybe.Maybe a
+  mkClientEnv :: http-client-0.7.17:Network.HTTP.Client.Types.Manager -> BaseUrl -> ClientEnv
+  parseBaseUrl :: forall (m :: * -> *). Control.Monad.Catch.MonadThrow m => GHC.Base.String -> m BaseUrl
+  runClientM :: forall a. Control.DeepSeq.NFData a => ClientM a -> ClientEnv -> GHC.Types.IO (Data.Either.Either ClientError a)
+  showBaseUrl :: BaseUrl -> GHC.Base.String
+  withClientM :: forall a b. ClientM a -> ClientEnv -> (Data.Either.Either ClientError a -> GHC.Types.IO b) -> GHC.Types.IO b
+
+
+-- Instances:
+instance aeson-2.2.3.0:Data.Aeson.Types.FromJSON.FromJSON Servant.Client.Core.BaseUrl.BaseUrl -- Defined in ‘Servant.Client.Core.BaseUrl’
+instance aeson-2.2.3.0:Data.Aeson.Types.FromJSON.FromJSONKey Servant.Client.Core.BaseUrl.BaseUrl -- Defined in ‘Servant.Client.Core.BaseUrl’
+instance aeson-2.2.3.0:Data.Aeson.Types.ToJSON.ToJSON Servant.Client.Core.BaseUrl.BaseUrl -- Defined in ‘Servant.Client.Core.BaseUrl’
+instance aeson-2.2.3.0:Data.Aeson.Types.ToJSON.ToJSONKey Servant.Client.Core.BaseUrl.BaseUrl -- Defined in ‘Servant.Client.Core.BaseUrl’
+instance Control.Monad.IO.Class.MonadIO Servant.Client.Internal.HttpClient.ClientM -- Defined in ‘Servant.Client.Internal.HttpClient’
+instance Control.Monad.IO.Class.MonadIO Servant.Client.Internal.HttpClient.Streaming.ClientM -- Defined in ‘Servant.Client.Internal.HttpClient.Streaming’
+instance Data.Data.Data Servant.Client.Core.BaseUrl.BaseUrl -- Defined in ‘Servant.Client.Core.BaseUrl’
+instance Data.Data.Data Servant.Client.Core.BaseUrl.Scheme -- Defined in ‘Servant.Client.Core.BaseUrl’
+instance Data.Foldable.Foldable Servant.Client.Core.Response.ResponseF -- Defined in ‘Servant.Client.Core.Response’
+instance Data.Traversable.Traversable Servant.Client.Core.Response.ResponseF -- Defined in ‘Servant.Client.Core.Response’
+instance GHC.Base.Applicative Servant.Client.Internal.HttpClient.ClientM -- Defined in ‘Servant.Client.Internal.HttpClient’
+instance GHC.Base.Applicative Servant.Client.Internal.HttpClient.Streaming.ClientM -- Defined in ‘Servant.Client.Internal.HttpClient.Streaming’
+instance GHC.Base.Functor Servant.Client.Internal.HttpClient.ClientM -- Defined in ‘Servant.Client.Internal.HttpClient’
+instance GHC.Base.Functor Servant.Client.Core.Response.ResponseF -- Defined in ‘Servant.Client.Core.Response’
+instance GHC.Base.Functor Servant.Client.Internal.HttpClient.Streaming.ClientM -- Defined in ‘Servant.Client.Internal.HttpClient.Streaming’
+instance GHC.Base.Monad Servant.Client.Internal.HttpClient.ClientM -- Defined in ‘Servant.Client.Internal.HttpClient’
+instance GHC.Base.Monad Servant.Client.Internal.HttpClient.Streaming.ClientM -- Defined in ‘Servant.Client.Internal.HttpClient.Streaming’
+instance GHC.Enum.Bounded Servant.Client.Core.HasClient.EmptyClient -- Defined in ‘Servant.Client.Core.HasClient’
+instance GHC.Enum.Enum Servant.Client.Core.HasClient.EmptyClient -- Defined in ‘Servant.Client.Core.HasClient’
+instance GHC.Exception.Type.Exception Servant.Client.Core.BaseUrl.InvalidBaseUrlException -- Defined in ‘Servant.Client.Core.BaseUrl’
+instance GHC.Exception.Type.Exception Servant.Client.Core.ClientError.ClientError -- Defined in ‘Servant.Client.Core.ClientError’
+instance GHC.Generics.Generic Servant.Client.Core.BaseUrl.BaseUrl -- Defined in ‘Servant.Client.Core.BaseUrl’
+instance GHC.Generics.Generic Servant.Client.Core.BaseUrl.Scheme -- Defined in ‘Servant.Client.Core.BaseUrl’
+instance forall a. GHC.Generics.Generic (Servant.Client.Internal.HttpClient.ClientM a) -- Defined in ‘Servant.Client.Internal.HttpClient’
+instance GHC.Generics.Generic Servant.Client.Core.ClientError.ClientError -- Defined in ‘Servant.Client.Core.ClientError’
+instance forall a. GHC.Generics.Generic (Servant.Client.Core.Response.ResponseF a) -- Defined in ‘Servant.Client.Core.Response’
+instance forall a. GHC.Generics.Generic (Servant.Client.Internal.HttpClient.Streaming.ClientM a) -- Defined in ‘Servant.Client.Internal.HttpClient.Streaming’
+instance GHC.Show.Show Servant.Client.Core.HasClient.ClientParseError -- Defined in ‘Servant.Client.Core.HasClient’
+instance GHC.Show.Show Servant.Client.Core.HasClient.EmptyClient -- Defined in ‘Servant.Client.Core.HasClient’
+instance GHC.Show.Show Servant.Client.Core.BaseUrl.BaseUrl -- Defined in ‘Servant.Client.Core.BaseUrl’
+instance GHC.Show.Show Servant.Client.Core.BaseUrl.InvalidBaseUrlException -- Defined in ‘Servant.Client.Core.BaseUrl’
+instance GHC.Show.Show Servant.Client.Core.BaseUrl.Scheme -- Defined in ‘Servant.Client.Core.BaseUrl’
+instance GHC.Show.Show Servant.Client.Core.ClientError.ClientError -- Defined in ‘Servant.Client.Core.ClientError’
+instance forall a. GHC.Show.Show a => GHC.Show.Show (Servant.Client.Core.Response.ResponseF a) -- Defined in ‘Servant.Client.Core.Response’
+instance Control.DeepSeq.NFData Servant.Client.Core.BaseUrl.BaseUrl -- Defined in ‘Servant.Client.Core.BaseUrl’
+instance Control.DeepSeq.NFData Servant.Client.Core.ClientError.ClientError -- Defined in ‘Servant.Client.Core.ClientError’
+instance forall a. Control.DeepSeq.NFData a => Control.DeepSeq.NFData (Servant.Client.Core.Response.ResponseF a) -- Defined in ‘Servant.Client.Core.Response’
+instance Control.Monad.Catch.MonadCatch Servant.Client.Internal.HttpClient.ClientM -- Defined in ‘Servant.Client.Internal.HttpClient’
+instance Control.Monad.Catch.MonadMask Servant.Client.Internal.HttpClient.ClientM -- Defined in ‘Servant.Client.Internal.HttpClient’
+instance Control.Monad.Catch.MonadThrow Servant.Client.Internal.HttpClient.ClientM -- Defined in ‘Servant.Client.Internal.HttpClient’
+instance GHC.Classes.Eq Servant.Client.Core.HasClient.ClientParseError -- Defined in ‘Servant.Client.Core.HasClient’
+instance GHC.Classes.Eq Servant.Client.Core.HasClient.EmptyClient -- Defined in ‘Servant.Client.Core.HasClient’
+instance GHC.Classes.Eq Servant.Client.Core.BaseUrl.BaseUrl -- Defined in ‘Servant.Client.Core.BaseUrl’
+instance GHC.Classes.Eq Servant.Client.Core.BaseUrl.Scheme -- Defined in ‘Servant.Client.Core.BaseUrl’
+instance GHC.Classes.Eq Servant.Client.Core.ClientError.ClientError -- Defined in ‘Servant.Client.Core.ClientError’
+instance forall a. GHC.Classes.Eq a => GHC.Classes.Eq (Servant.Client.Core.Response.ResponseF a) -- Defined in ‘Servant.Client.Core.Response’
+instance GHC.Classes.Ord Servant.Client.Core.BaseUrl.BaseUrl -- Defined in ‘Servant.Client.Core.BaseUrl’
+instance GHC.Classes.Ord Servant.Client.Core.BaseUrl.Scheme -- Defined in ‘Servant.Client.Core.BaseUrl’
+instance Control.Monad.Trans.Control.MonadBaseControl GHC.Types.IO Servant.Client.Internal.HttpClient.ClientM -- Defined in ‘Servant.Client.Internal.HttpClient’
+instance Control.Monad.Error.Class.MonadError Servant.Client.Core.ClientError.ClientError Servant.Client.Internal.HttpClient.ClientM -- Defined in ‘Servant.Client.Internal.HttpClient’
+instance Control.Monad.Error.Class.MonadError Servant.Client.Core.ClientError.ClientError Servant.Client.Internal.HttpClient.Streaming.ClientM -- Defined in ‘Servant.Client.Internal.HttpClient.Streaming’
+instance Control.Monad.Reader.Class.MonadReader Servant.Client.Internal.HttpClient.ClientEnv Servant.Client.Internal.HttpClient.ClientM -- Defined in ‘Servant.Client.Internal.HttpClient’
+instance Control.Monad.Reader.Class.MonadReader Servant.Client.Internal.HttpClient.ClientEnv Servant.Client.Internal.HttpClient.Streaming.ClientM -- Defined in ‘Servant.Client.Internal.HttpClient.Streaming’
+instance Data.Functor.Alt.Alt Servant.Client.Internal.HttpClient.ClientM -- Defined in ‘Servant.Client.Internal.HttpClient’
+instance Data.Functor.Alt.Alt Servant.Client.Internal.HttpClient.Streaming.ClientM -- Defined in ‘Servant.Client.Internal.HttpClient.Streaming’
+instance forall (m :: * -> *). Servant.API.Generic.GenericMode (Servant.Client.Core.HasClient.AsClientT m) -- Defined in ‘Servant.Client.Core.HasClient’
+instance [overlapping] forall a (x :: a) (xs :: [a]). Servant.API.UVerb.Union.UElem x (x : xs) -- Defined in ‘Servant.API.UVerb.Union’
+instance [overlapping] forall a (x :: a) (xs :: [a]) (x' :: a). Servant.API.UVerb.Union.UElem x xs => Servant.API.UVerb.Union.UElem x (x' : xs) -- Defined in ‘Servant.API.UVerb.Union’
+instance forall (api :: * -> *) (m :: * -> *). Servant.Client.Core.HasClient.GClientConstraints api m => Servant.Client.Core.HasClient.GClient api m -- Defined in ‘Servant.Client.Core.HasClient’
+instance forall (m :: * -> *) a b. (Servant.Client.Core.HasClient.HasClient m a, Servant.Client.Core.HasClient.HasClient m b) => Servant.Client.Core.HasClient.HasClient m (a Servant.API.Alternative.:<|> b) -- Defined in ‘Servant.Client.Core.HasClient’
+instance forall (path :: GHC.Types.Symbol) (m :: * -> *) api. (GHC.TypeLits.KnownSymbol path, Servant.Client.Core.HasClient.HasClient m api) => Servant.Client.Core.HasClient.HasClient m (path Servant.API.Sub.:> api) -- Defined in ‘Servant.Client.Core.HasClient’
+instance [overlappable] forall k (m :: * -> *) (ty :: k) sub. (Servant.Client.Core.RunClient.RunClient m, (TypeError ...)) => Servant.Client.Core.HasClient.HasClient m (ty Servant.API.Sub.:> sub) -- Defined in ‘Servant.Client.Core.HasClient’
+instance forall (m :: * -> *). Servant.Client.Core.RunClient.RunClient m => Servant.Client.Core.HasClient.HasClient m Servant.API.Empty.EmptyAPI -- Defined in ‘Servant.Client.Core.HasClient’
+instance forall (api :: * -> *) (m :: * -> *). (forall (n :: * -> *). Servant.Client.Core.HasClient.GClient api n, Servant.Client.Core.HasClient.HasClient m (Servant.API.Generic.ToServantApi api), Servant.Client.Core.RunClient.RunClient m, Servant.API.TypeErrors.ErrorIfNoGeneric api) => Servant.Client.Core.HasClient.HasClient m (Servant.API.NamedRoutes.NamedRoutes api) -- Defined in ‘Servant.Client.Core.HasClient’
+instance forall k1 (m :: * -> *) (method :: k1). (Servant.Client.Core.RunClient.RunClient m, Servant.API.Verbs.ReflectMethod method) => Servant.Client.Core.HasClient.HasClient m (Servant.API.Verbs.NoContentVerb method) -- Defined in ‘Servant.Client.Core.HasClient’
+instance forall (m :: * -> *). Servant.Client.Core.RunClient.RunClient m => Servant.Client.Core.HasClient.HasClient m Servant.API.Raw.Raw -- Defined in ‘Servant.Client.Core.HasClient’
+instance forall (m :: * -> *). Servant.Client.Core.RunClient.RunClient m => Servant.Client.Core.HasClient.HasClient m Servant.API.Raw.RawM -- Defined in ‘Servant.Client.Core.HasClient’
+instance [overlappable] forall k1 (m :: * -> *) ct chunk (method :: k1) framing a (status :: GHC.TypeNats.Nat). (Servant.Client.Core.RunClient.RunStreamingClient m, Servant.API.ContentTypes.MimeUnrender ct chunk, Servant.API.Verbs.ReflectMethod method, Servant.API.Stream.FramingUnrender framing, Servant.API.Stream.FromSourceIO chunk a) => Servant.Client.Core.HasClient.HasClient m (Servant.API.Stream.Stream method status framing ct a) -- Defined in ‘Servant.Client.Core.HasClient’
+instance [overlapping] forall k1 (m :: * -> *) ct chunk (method :: k1) framing a (hs :: [*]) (status :: GHC.TypeNats.Nat). (Servant.Client.Core.RunClient.RunStreamingClient m, Servant.API.ContentTypes.MimeUnrender ct chunk, Servant.API.Verbs.ReflectMethod method, Servant.API.Stream.FramingUnrender framing, Servant.API.Stream.FromSourceIO chunk a, Servant.API.ResponseHeaders.BuildHeadersTo hs) => Servant.Client.Core.HasClient.HasClient m (Servant.API.Stream.Stream method status framing ct (Servant.API.ResponseHeaders.Headers hs a)) -- Defined in ‘Servant.Client.Core.HasClient’
+instance [overlapping] forall (m :: * -> *) (contentTypes :: [*]) contentType (otherContentTypes :: [*]) (as :: [*]) a (as' :: [*]) (method :: Network.HTTP.Types.Method.StdMethod).
+                       (Servant.Client.Core.RunClient.RunClient m, contentTypes ~ (contentType : otherContentTypes), as ~ (a : as'), Servant.API.ContentTypes.AllMime contentTypes, Servant.API.Verbs.ReflectMethod method, Data.SOP.Constraint.All (Servant.Client.Core.HasClient.UnrenderResponse contentTypes) as, Data.SOP.Constraint.All Servant.API.UVerb.HasStatus as, Servant.API.UVerb.HasStatuses as', Servant.API.UVerb.Union.Unique (Servant.API.UVerb.Statuses as)) =>
+                       Servant.Client.Core.HasClient.HasClient m (Servant.API.UVerb.UVerb method contentTypes as)
+  -- Defined in ‘Servant.Client.Core.HasClient’
+instance [overlappable] forall k1 (m :: * -> *) ct a (method :: k1) (cts' :: [*]) (cts :: [*]) (status :: GHC.TypeNats.Nat). (Servant.Client.Core.RunClient.RunClient m, Servant.API.ContentTypes.MimeUnrender ct a, Servant.API.Verbs.ReflectMethod method, cts' ~ (ct : cts), GHC.TypeNats.KnownNat status) => Servant.Client.Core.HasClient.HasClient m (Servant.API.Verbs.Verb method status cts' a) -- Defined in ‘Servant.Client.Core.HasClient’
+instance [overlapping] forall k1 (m :: * -> *) (method :: k1) (status :: GHC.TypeNats.Nat) (cts :: [*]). (Servant.Client.Core.RunClient.RunClient m, Servant.API.Verbs.ReflectMethod method, GHC.TypeNats.KnownNat status) => Servant.Client.Core.HasClient.HasClient m (Servant.API.Verbs.Verb method status cts Servant.API.ContentTypes.NoContent) -- Defined in ‘Servant.Client.Core.HasClient’
+instance [overlapping] forall k1 (m :: * -> *) ct a (ls :: [*]) (status :: GHC.TypeNats.Nat) (method :: k1) (cts' :: [*]) (cts :: [*]). (Servant.Client.Core.RunClient.RunClient m, Servant.API.ContentTypes.MimeUnrender ct a, Servant.API.ResponseHeaders.BuildHeadersTo ls, GHC.TypeNats.KnownNat status, Servant.API.Verbs.ReflectMethod method, cts' ~ (ct : cts)) => Servant.Client.Core.HasClient.HasClient m (Servant.API.Verbs.Verb method status cts' (Servant.API.ResponseHeaders.Headers ls a)) -- Defined in ‘Servant.Client.Core.HasClient’
+instance [overlapping] forall k1 (m :: * -> *) (ls :: [*]) (method :: k1) (status :: GHC.TypeNats.Nat) (cts :: [*]). (Servant.Client.Core.RunClient.RunClient m, Servant.API.ResponseHeaders.BuildHeadersTo ls, Servant.API.Verbs.ReflectMethod method, GHC.TypeNats.KnownNat status) => Servant.Client.Core.HasClient.HasClient m (Servant.API.Verbs.Verb method status cts (Servant.API.ResponseHeaders.Headers ls Servant.API.ContentTypes.NoContent)) -- Defined in ‘Servant.Client.Core.HasClient’
+instance forall (m :: * -> *) subapi (name :: GHC.Types.Symbol) (context :: [*]). Servant.Client.Core.HasClient.HasClient m subapi => Servant.Client.Core.HasClient.HasClient m (Servant.API.WithNamedContext.WithNamedContext name context subapi) -- Defined in ‘Servant.Client.Core.HasClient’
+instance [overlappable] forall (m :: * -> *) api. (Servant.Client.Core.RunClient.RunClient m, (TypeError ...)) => Servant.Client.Core.HasClient.HasClient m api -- Defined in ‘Servant.Client.Core.HasClient’
+instance [overlapping] forall (cts :: [*]) a (h :: [*]). (Servant.Client.Core.HasClient.UnrenderResponse cts a, Servant.API.ResponseHeaders.BuildHeadersTo h) => Servant.Client.Core.HasClient.UnrenderResponse cts (Servant.API.ResponseHeaders.Headers h a) -- Defined in ‘Servant.Client.Core.HasClient’
+instance [overlapping] forall (cts :: [*]) a (n :: GHC.TypeNats.Nat). Servant.Client.Core.HasClient.UnrenderResponse cts a => Servant.Client.Core.HasClient.UnrenderResponse cts (Servant.API.UVerb.WithStatus n a) -- Defined in ‘Servant.Client.Core.HasClient’
+instance [overlappable] forall (cts :: [*]) a. Servant.API.ContentTypes.AllMimeUnrender cts a => Servant.Client.Core.HasClient.UnrenderResponse cts a -- Defined in ‘Servant.Client.Core.HasClient’
+instance Servant.Client.Core.RunClient.RunClient Servant.Client.Internal.HttpClient.ClientM -- Defined in ‘Servant.Client.Internal.HttpClient’
+instance Servant.Client.Core.RunClient.RunClient Servant.Client.Internal.HttpClient.Streaming.ClientM -- Defined in ‘Servant.Client.Internal.HttpClient.Streaming’
+instance Servant.Client.Core.RunClient.RunStreamingClient Servant.Client.Internal.HttpClient.Streaming.ClientM -- Defined in ‘Servant.Client.Internal.HttpClient.Streaming’
+instance Language.Haskell.TH.Syntax.Lift Servant.Client.Core.BaseUrl.BaseUrl -- Defined in ‘Servant.Client.Core.BaseUrl’
+instance Language.Haskell.TH.Syntax.Lift Servant.Client.Core.BaseUrl.Scheme -- Defined in ‘Servant.Client.Core.BaseUrl’
+instance Control.Monad.Base.MonadBase GHC.Types.IO Servant.Client.Internal.HttpClient.ClientM -- Defined in ‘Servant.Client.Internal.HttpClient’
+instance Control.Monad.Base.MonadBase GHC.Types.IO Servant.Client.Internal.HttpClient.Streaming.ClientM -- Defined in ‘Servant.Client.Internal.HttpClient.Streaming’

--- a/test/golden/servant-client-actual-api.txt
+++ b/test/golden/servant-client-actual-api.txt
@@ -1,4 +1,3 @@
-
 module Servant.Client where
   (//) :: forall a b. a -> (a -> b) -> b
   (/:) :: forall a b c. (a -> b -> c) -> b -> a -> c

--- a/test/golden/servant-client-expected-api.txt
+++ b/test/golden/servant-client-expected-api.txt
@@ -1,0 +1,192 @@
+module Servant.Client where
+  (//) :: forall a b. a -> (a -> b) -> b
+  (/:) :: forall a b c. (a -> b -> c) -> b -> a -> c
+  type role AsClientT phantom
+  type AsClientT :: (* -> *) -> *
+  data AsClientT m
+  type BaseUrl :: *
+  data BaseUrl = BaseUrl {baseUrlScheme :: Scheme, baseUrlHost :: GHC.Base.String, baseUrlPort :: GHC.Types.Int, baseUrlPath :: GHC.Base.String}
+  type ClientEnv :: *
+  data ClientEnv = ClientEnv {manager :: http-client-0.7.17:Network.HTTP.Client.Types.Manager, baseUrl :: BaseUrl, cookieJar :: GHC.Maybe.Maybe (GHC.Conc.Sync.TVar http-client-0.7.17:Network.HTTP.Client.Types.CookieJar), makeClientRequest :: BaseUrl -> Servant.Client.Core.Request.Request -> GHC.Types.IO http-client-0.7.17:Network.HTTP.Client.Types.Request}
+  type ClientError :: *
+  data ClientError = FailureResponse (Servant.Client.Core.Request.RequestF () (BaseUrl, bytestring-0.11.5.3:Data.ByteString.Internal.Type.ByteString)) Response | DecodeFailure Data.Text.Internal.Text Response | UnsupportedContentType http-media-0.8.1.1:Network.HTTP.Media.MediaType.Internal.MediaType Response | InvalidContentTypeHeader Response | ConnectionError GHC.Exception.Type.SomeException
+  type role ClientM nominal
+  type ClientM :: * -> *
+  newtype ClientM a = Servant.Client.Internal.HttpClient.ClientM {Servant.Client.Internal.HttpClient.unClientM :: Control.Monad.Trans.Reader.ReaderT ClientEnv (Control.Monad.Trans.Except.ExceptT ClientError GHC.Types.IO) a}
+  type EmptyClient :: *
+  data EmptyClient = EmptyClient
+  type HasClient :: (* -> *) -> * -> Constraint
+  class Servant.Client.Core.RunClient.RunClient m => HasClient m api where
+    type Client :: (* -> *) -> * -> *
+    type family Client m api
+    clientWithRoute :: Data.Proxy.Proxy m -> Data.Proxy.Proxy api -> Servant.Client.Core.Request.Request -> Client m api
+    hoistClientMonad :: forall (mon :: * -> *) (mon' :: * -> *). Data.Proxy.Proxy m -> Data.Proxy.Proxy api -> (forall x. mon x -> mon' x) -> Client mon api -> Client mon' api
+    {-# MINIMAL clientWithRoute, hoistClientMonad #-}
+    {-# MINIMAL clientWithRoute, hoistClientMonad #-}
+  type InvalidBaseUrlException :: *
+  newtype InvalidBaseUrlException = Servant.Client.Core.BaseUrl.InvalidBaseUrlException GHC.Base.String
+  type Response :: *
+  type Response = ResponseF Data.ByteString.Lazy.Internal.ByteString
+  type ResponseF :: * -> *
+  data ResponseF a = Response {responseStatusCode :: Network.HTTP.Types.Status.Status, responseHeaders :: Data.Sequence.Internal.Seq Network.HTTP.Types.Header.Header, responseHttpVersion :: Network.HTTP.Types.Version.HttpVersion, responseBody :: a}
+  type Scheme :: *
+  data Scheme = Http | Https
+  type StreamingResponse :: *
+  type StreamingResponse = ResponseF (Servant.API.Stream.SourceIO bytestring-0.11.5.3:Data.ByteString.Internal.Type.ByteString)
+  client :: forall api. HasClient ClientM api => Data.Proxy.Proxy api -> Client ClientM api
+  defaultMakeClientRequest :: BaseUrl -> Servant.Client.Core.Request.Request -> GHC.Types.IO http-client-0.7.17:Network.HTTP.Client.Types.Request
+  foldMapUnion :: forall (c :: * -> Constraint) a (as :: [*]). Data.SOP.Constraint.All c as => Data.Proxy.Proxy c -> (forall x. c x => x -> a) -> Servant.API.UVerb.Union.Union as -> a
+  hoistClient :: forall api (m :: * -> *) (n :: * -> *). HasClient ClientM api => Data.Proxy.Proxy api -> (forall a. m a -> n a) -> Client m api -> Client n api
+  matchUnion :: forall a (as :: [*]). Servant.API.UVerb.Union.IsMember a as => Servant.API.UVerb.Union.Union as -> GHC.Maybe.Maybe a
+  mkClientEnv :: http-client-0.7.17:Network.HTTP.Client.Types.Manager -> BaseUrl -> ClientEnv
+  parseBaseUrl :: forall (m :: * -> *). Control.Monad.Catch.MonadThrow m => GHC.Base.String -> m BaseUrl
+  runClientM :: forall a. ClientM a -> ClientEnv -> GHC.Types.IO (Data.Either.Either ClientError a)
+  showBaseUrl :: BaseUrl -> GHC.Base.String
+
+module Servant.Client.Internal.HttpClient where
+
+-- ignored
+
+
+module Servant.Client.Internal.HttpClient.Streaming where
+
+-- ignored
+
+
+module Servant.Client.Streaming where
+  (//) :: forall a b. a -> (a -> b) -> b
+  (/:) :: forall a b c. (a -> b -> c) -> b -> a -> c
+  type role AsClientT phantom
+  type AsClientT :: (* -> *) -> *
+  data AsClientT m
+  type BaseUrl :: *
+  data BaseUrl = BaseUrl {baseUrlScheme :: Scheme, baseUrlHost :: GHC.Base.String, baseUrlPort :: GHC.Types.Int, baseUrlPath :: GHC.Base.String}
+  type ClientEnv :: *
+  data ClientEnv = ClientEnv {manager :: http-client-0.7.17:Network.HTTP.Client.Types.Manager, baseUrl :: BaseUrl, cookieJar :: GHC.Maybe.Maybe (GHC.Conc.Sync.TVar http-client-0.7.17:Network.HTTP.Client.Types.CookieJar), makeClientRequest :: BaseUrl -> Servant.Client.Core.Request.Request -> GHC.Types.IO http-client-0.7.17:Network.HTTP.Client.Types.Request}
+  type ClientError :: *
+  data ClientError = FailureResponse (Servant.Client.Core.Request.RequestF () (BaseUrl, bytestring-0.11.5.3:Data.ByteString.Internal.Type.ByteString)) Response | DecodeFailure Data.Text.Internal.Text Response | UnsupportedContentType http-media-0.8.1.1:Network.HTTP.Media.MediaType.Internal.MediaType Response | InvalidContentTypeHeader Response | ConnectionError GHC.Exception.Type.SomeException
+  type role ClientM nominal
+  type ClientM :: * -> *
+  newtype ClientM a = Servant.Client.Internal.HttpClient.Streaming.ClientM {Servant.Client.Internal.HttpClient.Streaming.unClientM :: Control.Monad.Trans.Reader.ReaderT ClientEnv (Control.Monad.Trans.Except.ExceptT ClientError (Control.Monad.Codensity.Codensity GHC.Types.IO)) a}
+  type EmptyClient :: *
+  data EmptyClient = EmptyClient
+  type HasClient :: (* -> *) -> * -> Constraint
+  class Servant.Client.Core.RunClient.RunClient m => HasClient m api where
+    type Client :: (* -> *) -> * -> *
+    type family Client m api
+    clientWithRoute :: Data.Proxy.Proxy m -> Data.Proxy.Proxy api -> Servant.Client.Core.Request.Request -> Client m api
+    hoistClientMonad :: forall (mon :: * -> *) (mon' :: * -> *). Data.Proxy.Proxy m -> Data.Proxy.Proxy api -> (forall x. mon x -> mon' x) -> Client mon api -> Client mon' api
+    {-# MINIMAL clientWithRoute, hoistClientMonad #-}
+    {-# MINIMAL clientWithRoute, hoistClientMonad #-}
+  type InvalidBaseUrlException :: *
+  newtype InvalidBaseUrlException = Servant.Client.Core.BaseUrl.InvalidBaseUrlException GHC.Base.String
+  type Response :: *
+  type Response = ResponseF Data.ByteString.Lazy.Internal.ByteString
+  type ResponseF :: * -> *
+  data ResponseF a = Response {responseStatusCode :: Network.HTTP.Types.Status.Status, responseHeaders :: Data.Sequence.Internal.Seq Network.HTTP.Types.Header.Header, responseHttpVersion :: Network.HTTP.Types.Version.HttpVersion, responseBody :: a}
+  type Scheme :: *
+  data Scheme = Http | Https
+  type StreamingResponse :: *
+  type StreamingResponse = ResponseF (Servant.API.Stream.SourceIO bytestring-0.11.5.3:Data.ByteString.Internal.Type.ByteString)
+  client :: forall api. HasClient ClientM api => Data.Proxy.Proxy api -> Client ClientM api
+  defaultMakeClientRequest :: BaseUrl -> Servant.Client.Core.Request.Request -> GHC.Types.IO http-client-0.7.17:Network.HTTP.Client.Types.Request
+  foldMapUnion :: forall (c :: * -> Constraint) a (as :: [*]). Data.SOP.Constraint.All c as => Data.Proxy.Proxy c -> (forall x. c x => x -> a) -> Servant.API.UVerb.Union.Union as -> a
+  hoistClient :: forall api (m :: * -> *) (n :: * -> *). HasClient ClientM api => Data.Proxy.Proxy api -> (forall a. m a -> n a) -> Client m api -> Client n api
+  matchUnion :: forall a (as :: [*]). Servant.API.UVerb.Union.IsMember a as => Servant.API.UVerb.Union.Union as -> GHC.Maybe.Maybe a
+  mkClientEnv :: http-client-0.7.17:Network.HTTP.Client.Types.Manager -> BaseUrl -> ClientEnv
+  parseBaseUrl :: forall (m :: * -> *). Control.Monad.Catch.MonadThrow m => GHC.Base.String -> m BaseUrl
+  runClientM :: forall a. Control.DeepSeq.NFData a => ClientM a -> ClientEnv -> GHC.Types.IO (Data.Either.Either ClientError a)
+  showBaseUrl :: BaseUrl -> GHC.Base.String
+  withClientM :: forall a b. ClientM a -> ClientEnv -> (Data.Either.Either ClientError a -> GHC.Types.IO b) -> GHC.Types.IO b
+
+
+-- Instances:
+instance aeson-2.2.3.0:Data.Aeson.Types.FromJSON.FromJSON Servant.Client.Core.BaseUrl.BaseUrl -- Defined in ‘Servant.Client.Core.BaseUrl’
+instance aeson-2.2.3.0:Data.Aeson.Types.FromJSON.FromJSONKey Servant.Client.Core.BaseUrl.BaseUrl -- Defined in ‘Servant.Client.Core.BaseUrl’
+instance aeson-2.2.3.0:Data.Aeson.Types.ToJSON.ToJSON Servant.Client.Core.BaseUrl.BaseUrl -- Defined in ‘Servant.Client.Core.BaseUrl’
+instance aeson-2.2.3.0:Data.Aeson.Types.ToJSON.ToJSONKey Servant.Client.Core.BaseUrl.BaseUrl -- Defined in ‘Servant.Client.Core.BaseUrl’
+instance Control.Monad.IO.Class.MonadIO Servant.Client.Internal.HttpClient.ClientM -- Defined in ‘Servant.Client.Internal.HttpClient’
+instance Control.Monad.IO.Class.MonadIO Servant.Client.Internal.HttpClient.Streaming.ClientM -- Defined in ‘Servant.Client.Internal.HttpClient.Streaming’
+instance Data.Data.Data Servant.Client.Core.BaseUrl.BaseUrl -- Defined in ‘Servant.Client.Core.BaseUrl’
+instance Data.Data.Data Servant.Client.Core.BaseUrl.Scheme -- Defined in ‘Servant.Client.Core.BaseUrl’
+instance Data.Foldable.Foldable Servant.Client.Core.Response.ResponseF -- Defined in ‘Servant.Client.Core.Response’
+instance Data.Traversable.Traversable Servant.Client.Core.Response.ResponseF -- Defined in ‘Servant.Client.Core.Response’
+instance GHC.Base.Applicative Servant.Client.Internal.HttpClient.ClientM -- Defined in ‘Servant.Client.Internal.HttpClient’
+instance GHC.Base.Applicative Servant.Client.Internal.HttpClient.Streaming.ClientM -- Defined in ‘Servant.Client.Internal.HttpClient.Streaming’
+instance GHC.Base.Functor Servant.Client.Internal.HttpClient.ClientM -- Defined in ‘Servant.Client.Internal.HttpClient’
+instance GHC.Base.Functor Servant.Client.Core.Response.ResponseF -- Defined in ‘Servant.Client.Core.Response’
+instance GHC.Base.Functor Servant.Client.Internal.HttpClient.Streaming.ClientM -- Defined in ‘Servant.Client.Internal.HttpClient.Streaming’
+instance GHC.Base.Monad Servant.Client.Internal.HttpClient.ClientM -- Defined in ‘Servant.Client.Internal.HttpClient’
+instance GHC.Base.Monad Servant.Client.Internal.HttpClient.Streaming.ClientM -- Defined in ‘Servant.Client.Internal.HttpClient.Streaming’
+instance GHC.Enum.Bounded Servant.Client.Core.HasClient.EmptyClient -- Defined in ‘Servant.Client.Core.HasClient’
+instance GHC.Enum.Enum Servant.Client.Core.HasClient.EmptyClient -- Defined in ‘Servant.Client.Core.HasClient’
+instance GHC.Exception.Type.Exception Servant.Client.Core.BaseUrl.InvalidBaseUrlException -- Defined in ‘Servant.Client.Core.BaseUrl’
+instance GHC.Exception.Type.Exception Servant.Client.Core.ClientError.ClientError -- Defined in ‘Servant.Client.Core.ClientError’
+instance GHC.Generics.Generic Servant.Client.Core.BaseUrl.BaseUrl -- Defined in ‘Servant.Client.Core.BaseUrl’
+instance GHC.Generics.Generic Servant.Client.Core.BaseUrl.Scheme -- Defined in ‘Servant.Client.Core.BaseUrl’
+instance forall a. GHC.Generics.Generic (Servant.Client.Internal.HttpClient.ClientM a) -- Defined in ‘Servant.Client.Internal.HttpClient’
+instance GHC.Generics.Generic Servant.Client.Core.ClientError.ClientError -- Defined in ‘Servant.Client.Core.ClientError’
+instance forall a. GHC.Generics.Generic (Servant.Client.Core.Response.ResponseF a) -- Defined in ‘Servant.Client.Core.Response’
+instance forall a. GHC.Generics.Generic (Servant.Client.Internal.HttpClient.Streaming.ClientM a) -- Defined in ‘Servant.Client.Internal.HttpClient.Streaming’
+instance GHC.Show.Show Servant.Client.Core.HasClient.ClientParseError -- Defined in ‘Servant.Client.Core.HasClient’
+instance GHC.Show.Show Servant.Client.Core.HasClient.EmptyClient -- Defined in ‘Servant.Client.Core.HasClient’
+instance GHC.Show.Show Servant.Client.Core.BaseUrl.BaseUrl -- Defined in ‘Servant.Client.Core.BaseUrl’
+instance GHC.Show.Show Servant.Client.Core.BaseUrl.InvalidBaseUrlException -- Defined in ‘Servant.Client.Core.BaseUrl’
+instance GHC.Show.Show Servant.Client.Core.BaseUrl.Scheme -- Defined in ‘Servant.Client.Core.BaseUrl’
+instance GHC.Show.Show Servant.Client.Core.ClientError.ClientError -- Defined in ‘Servant.Client.Core.ClientError’
+instance forall a. GHC.Show.Show a => GHC.Show.Show (Servant.Client.Core.Response.ResponseF a) -- Defined in ‘Servant.Client.Core.Response’
+instance Control.DeepSeq.NFData Servant.Client.Core.BaseUrl.BaseUrl -- Defined in ‘Servant.Client.Core.BaseUrl’
+instance Control.DeepSeq.NFData Servant.Client.Core.ClientError.ClientError -- Defined in ‘Servant.Client.Core.ClientError’
+instance forall a. Control.DeepSeq.NFData a => Control.DeepSeq.NFData (Servant.Client.Core.Response.ResponseF a) -- Defined in ‘Servant.Client.Core.Response’
+instance Control.Monad.Catch.MonadCatch Servant.Client.Internal.HttpClient.ClientM -- Defined in ‘Servant.Client.Internal.HttpClient’
+instance Control.Monad.Catch.MonadMask Servant.Client.Internal.HttpClient.ClientM -- Defined in ‘Servant.Client.Internal.HttpClient’
+instance Control.Monad.Catch.MonadThrow Servant.Client.Internal.HttpClient.ClientM -- Defined in ‘Servant.Client.Internal.HttpClient’
+instance GHC.Classes.Eq Servant.Client.Core.HasClient.ClientParseError -- Defined in ‘Servant.Client.Core.HasClient’
+instance GHC.Classes.Eq Servant.Client.Core.HasClient.EmptyClient -- Defined in ‘Servant.Client.Core.HasClient’
+instance GHC.Classes.Eq Servant.Client.Core.BaseUrl.BaseUrl -- Defined in ‘Servant.Client.Core.BaseUrl’
+instance GHC.Classes.Eq Servant.Client.Core.BaseUrl.Scheme -- Defined in ‘Servant.Client.Core.BaseUrl’
+instance GHC.Classes.Eq Servant.Client.Core.ClientError.ClientError -- Defined in ‘Servant.Client.Core.ClientError’
+instance forall a. GHC.Classes.Eq a => GHC.Classes.Eq (Servant.Client.Core.Response.ResponseF a) -- Defined in ‘Servant.Client.Core.Response’
+instance GHC.Classes.Ord Servant.Client.Core.BaseUrl.BaseUrl -- Defined in ‘Servant.Client.Core.BaseUrl’
+instance GHC.Classes.Ord Servant.Client.Core.BaseUrl.Scheme -- Defined in ‘Servant.Client.Core.BaseUrl’
+instance Control.Monad.Trans.Control.MonadBaseControl GHC.Types.IO Servant.Client.Internal.HttpClient.ClientM -- Defined in ‘Servant.Client.Internal.HttpClient’
+instance Control.Monad.Error.Class.MonadError Servant.Client.Core.ClientError.ClientError Servant.Client.Internal.HttpClient.ClientM -- Defined in ‘Servant.Client.Internal.HttpClient’
+instance Control.Monad.Error.Class.MonadError Servant.Client.Core.ClientError.ClientError Servant.Client.Internal.HttpClient.Streaming.ClientM -- Defined in ‘Servant.Client.Internal.HttpClient.Streaming’
+instance Control.Monad.Reader.Class.MonadReader Servant.Client.Internal.HttpClient.ClientEnv Servant.Client.Internal.HttpClient.ClientM -- Defined in ‘Servant.Client.Internal.HttpClient’
+instance Control.Monad.Reader.Class.MonadReader Servant.Client.Internal.HttpClient.ClientEnv Servant.Client.Internal.HttpClient.Streaming.ClientM -- Defined in ‘Servant.Client.Internal.HttpClient.Streaming’
+instance Data.Functor.Alt.Alt Servant.Client.Internal.HttpClient.ClientM -- Defined in ‘Servant.Client.Internal.HttpClient’
+instance Data.Functor.Alt.Alt Servant.Client.Internal.HttpClient.Streaming.ClientM -- Defined in ‘Servant.Client.Internal.HttpClient.Streaming’
+instance forall (m :: * -> *). Servant.API.Generic.GenericMode (Servant.Client.Core.HasClient.AsClientT m) -- Defined in ‘Servant.Client.Core.HasClient’
+instance [overlapping] forall a (x :: a) (xs :: [a]). Servant.API.UVerb.Union.UElem x (x : xs) -- Defined in ‘Servant.API.UVerb.Union’
+instance [overlapping] forall a (x :: a) (xs :: [a]) (x' :: a). Servant.API.UVerb.Union.UElem x xs => Servant.API.UVerb.Union.UElem x (x' : xs) -- Defined in ‘Servant.API.UVerb.Union’
+instance forall (api :: * -> *) (m :: * -> *). Servant.Client.Core.HasClient.GClientConstraints api m => Servant.Client.Core.HasClient.GClient api m -- Defined in ‘Servant.Client.Core.HasClient’
+instance forall (m :: * -> *) a b. (Servant.Client.Core.HasClient.HasClient m a, Servant.Client.Core.HasClient.HasClient m b) => Servant.Client.Core.HasClient.HasClient m (a Servant.API.Alternative.:<|> b) -- Defined in ‘Servant.Client.Core.HasClient’
+instance forall (path :: GHC.Types.Symbol) (m :: * -> *) api. (GHC.TypeLits.KnownSymbol path, Servant.Client.Core.HasClient.HasClient m api) => Servant.Client.Core.HasClient.HasClient m (path Servant.API.Sub.:> api) -- Defined in ‘Servant.Client.Core.HasClient’
+instance [overlappable] forall k (m :: * -> *) (ty :: k) sub. (Servant.Client.Core.RunClient.RunClient m, (TypeError ...)) => Servant.Client.Core.HasClient.HasClient m (ty Servant.API.Sub.:> sub) -- Defined in ‘Servant.Client.Core.HasClient’
+instance forall (m :: * -> *). Servant.Client.Core.RunClient.RunClient m => Servant.Client.Core.HasClient.HasClient m Servant.API.Empty.EmptyAPI -- Defined in ‘Servant.Client.Core.HasClient’
+instance forall (api :: * -> *) (m :: * -> *). (forall (n :: * -> *). Servant.Client.Core.HasClient.GClient api n, Servant.Client.Core.HasClient.HasClient m (Servant.API.Generic.ToServantApi api), Servant.Client.Core.RunClient.RunClient m, Servant.API.TypeErrors.ErrorIfNoGeneric api) => Servant.Client.Core.HasClient.HasClient m (Servant.API.NamedRoutes.NamedRoutes api) -- Defined in ‘Servant.Client.Core.HasClient’
+instance forall k1 (m :: * -> *) (method :: k1). (Servant.Client.Core.RunClient.RunClient m, Servant.API.Verbs.ReflectMethod method) => Servant.Client.Core.HasClient.HasClient m (Servant.API.Verbs.NoContentVerb method) -- Defined in ‘Servant.Client.Core.HasClient’
+instance forall (m :: * -> *). Servant.Client.Core.RunClient.RunClient m => Servant.Client.Core.HasClient.HasClient m Servant.API.Raw.Raw -- Defined in ‘Servant.Client.Core.HasClient’
+instance forall (m :: * -> *). Servant.Client.Core.RunClient.RunClient m => Servant.Client.Core.HasClient.HasClient m Servant.API.Raw.RawM -- Defined in ‘Servant.Client.Core.HasClient’
+instance [overlappable] forall k1 (m :: * -> *) ct chunk (method :: k1) framing a (status :: GHC.TypeNats.Nat). (Servant.Client.Core.RunClient.RunStreamingClient m, Servant.API.ContentTypes.MimeUnrender ct chunk, Servant.API.Verbs.ReflectMethod method, Servant.API.Stream.FramingUnrender framing, Servant.API.Stream.FromSourceIO chunk a) => Servant.Client.Core.HasClient.HasClient m (Servant.API.Stream.Stream method status framing ct a) -- Defined in ‘Servant.Client.Core.HasClient’
+instance [overlapping] forall k1 (m :: * -> *) ct chunk (method :: k1) framing a (hs :: [*]) (status :: GHC.TypeNats.Nat). (Servant.Client.Core.RunClient.RunStreamingClient m, Servant.API.ContentTypes.MimeUnrender ct chunk, Servant.API.Verbs.ReflectMethod method, Servant.API.Stream.FramingUnrender framing, Servant.API.Stream.FromSourceIO chunk a, Servant.API.ResponseHeaders.BuildHeadersTo hs) => Servant.Client.Core.HasClient.HasClient m (Servant.API.Stream.Stream method status framing ct (Servant.API.ResponseHeaders.Headers hs a)) -- Defined in ‘Servant.Client.Core.HasClient’
+instance [overlapping] forall (m :: * -> *) (contentTypes :: [*]) contentType (otherContentTypes :: [*]) (as :: [*]) a (as' :: [*]) (method :: Network.HTTP.Types.Method.StdMethod).
+                       (Servant.Client.Core.RunClient.RunClient m, contentTypes ~ (contentType : otherContentTypes), as ~ (a : as'), Servant.API.ContentTypes.AllMime contentTypes, Servant.API.Verbs.ReflectMethod method, Data.SOP.Constraint.All (Servant.Client.Core.HasClient.UnrenderResponse contentTypes) as, Data.SOP.Constraint.All Servant.API.UVerb.HasStatus as, Servant.API.UVerb.HasStatuses as', Servant.API.UVerb.Union.Unique (Servant.API.UVerb.Statuses as)) =>
+                       Servant.Client.Core.HasClient.HasClient m (Servant.API.UVerb.UVerb method contentTypes as)
+  -- Defined in ‘Servant.Client.Core.HasClient’
+instance [overlappable] forall k1 (m :: * -> *) ct a (method :: k1) (cts' :: [*]) (cts :: [*]) (status :: GHC.TypeNats.Nat). (Servant.Client.Core.RunClient.RunClient m, Servant.API.ContentTypes.MimeUnrender ct a, Servant.API.Verbs.ReflectMethod method, cts' ~ (ct : cts), GHC.TypeNats.KnownNat status) => Servant.Client.Core.HasClient.HasClient m (Servant.API.Verbs.Verb method status cts' a) -- Defined in ‘Servant.Client.Core.HasClient’
+instance [overlapping] forall k1 (m :: * -> *) (method :: k1) (status :: GHC.TypeNats.Nat) (cts :: [*]). (Servant.Client.Core.RunClient.RunClient m, Servant.API.Verbs.ReflectMethod method, GHC.TypeNats.KnownNat status) => Servant.Client.Core.HasClient.HasClient m (Servant.API.Verbs.Verb method status cts Servant.API.ContentTypes.NoContent) -- Defined in ‘Servant.Client.Core.HasClient’
+instance [overlapping] forall k1 (m :: * -> *) ct a (ls :: [*]) (status :: GHC.TypeNats.Nat) (method :: k1) (cts' :: [*]) (cts :: [*]). (Servant.Client.Core.RunClient.RunClient m, Servant.API.ContentTypes.MimeUnrender ct a, Servant.API.ResponseHeaders.BuildHeadersTo ls, GHC.TypeNats.KnownNat status, Servant.API.Verbs.ReflectMethod method, cts' ~ (ct : cts)) => Servant.Client.Core.HasClient.HasClient m (Servant.API.Verbs.Verb method status cts' (Servant.API.ResponseHeaders.Headers ls a)) -- Defined in ‘Servant.Client.Core.HasClient’
+instance [overlapping] forall k1 (m :: * -> *) (ls :: [*]) (method :: k1) (status :: GHC.TypeNats.Nat) (cts :: [*]). (Servant.Client.Core.RunClient.RunClient m, Servant.API.ResponseHeaders.BuildHeadersTo ls, Servant.API.Verbs.ReflectMethod method, GHC.TypeNats.KnownNat status) => Servant.Client.Core.HasClient.HasClient m (Servant.API.Verbs.Verb method status cts (Servant.API.ResponseHeaders.Headers ls Servant.API.ContentTypes.NoContent)) -- Defined in ‘Servant.Client.Core.HasClient’
+instance forall (m :: * -> *) subapi (name :: GHC.Types.Symbol) (context :: [*]). Servant.Client.Core.HasClient.HasClient m subapi => Servant.Client.Core.HasClient.HasClient m (Servant.API.WithNamedContext.WithNamedContext name context subapi) -- Defined in ‘Servant.Client.Core.HasClient’
+instance [overlappable] forall (m :: * -> *) api. (Servant.Client.Core.RunClient.RunClient m, (TypeError ...)) => Servant.Client.Core.HasClient.HasClient m api -- Defined in ‘Servant.Client.Core.HasClient’
+instance [overlapping] forall (cts :: [*]) a (h :: [*]). (Servant.Client.Core.HasClient.UnrenderResponse cts a, Servant.API.ResponseHeaders.BuildHeadersTo h) => Servant.Client.Core.HasClient.UnrenderResponse cts (Servant.API.ResponseHeaders.Headers h a) -- Defined in ‘Servant.Client.Core.HasClient’
+instance [overlapping] forall (cts :: [*]) a (n :: GHC.TypeNats.Nat). Servant.Client.Core.HasClient.UnrenderResponse cts a => Servant.Client.Core.HasClient.UnrenderResponse cts (Servant.API.UVerb.WithStatus n a) -- Defined in ‘Servant.Client.Core.HasClient’
+instance [overlappable] forall (cts :: [*]) a. Servant.API.ContentTypes.AllMimeUnrender cts a => Servant.Client.Core.HasClient.UnrenderResponse cts a -- Defined in ‘Servant.Client.Core.HasClient’
+instance Servant.Client.Core.RunClient.RunClient Servant.Client.Internal.HttpClient.ClientM -- Defined in ‘Servant.Client.Internal.HttpClient’
+instance Servant.Client.Core.RunClient.RunClient Servant.Client.Internal.HttpClient.Streaming.ClientM -- Defined in ‘Servant.Client.Internal.HttpClient.Streaming’
+instance Servant.Client.Core.RunClient.RunStreamingClient Servant.Client.Internal.HttpClient.Streaming.ClientM -- Defined in ‘Servant.Client.Internal.HttpClient.Streaming’
+instance Language.Haskell.TH.Syntax.Lift Servant.Client.Core.BaseUrl.BaseUrl -- Defined in ‘Servant.Client.Core.BaseUrl’
+instance Language.Haskell.TH.Syntax.Lift Servant.Client.Core.BaseUrl.Scheme -- Defined in ‘Servant.Client.Core.BaseUrl’
+instance Control.Monad.Base.MonadBase GHC.Types.IO Servant.Client.Internal.HttpClient.ClientM -- Defined in ‘Servant.Client.Internal.HttpClient’
+instance Control.Monad.Base.MonadBase GHC.Types.IO Servant.Client.Internal.HttpClient.Streaming.ClientM -- Defined in ‘Servant.Client.Internal.HttpClient.Streaming’

--- a/test/golden/servant-client-ignore-list.txt
+++ b/test/golden/servant-client-ignore-list.txt
@@ -1,0 +1,2 @@
+Servant.Client.Internal.HttpClient
+Servant.Client.Internal.HttpClient.Streaming


### PR DESCRIPTION
This PR adds support for user-supplied ignore lists for modules.

With the example of `servant-client`, we can achieve this kind of result:

<details>
<summary>Original</summary>

```
module Servant.Client where
  (//) :: forall a b. a -> (a -> b) -> b
  (/:) :: forall a b c. (a -> b -> c) -> b -> a -> c
  type role AsClientT phantom
  type AsClientT :: (* -> *) -> *
  data AsClientT m
  type BaseUrl :: *
  data BaseUrl = BaseUrl {baseUrlScheme :: Scheme, baseUrlHost :: GHC.Base.String, baseUrlPort :: GHC.Types.Int, baseUrlPath :: GHC.Base.String}
  type ClientEnv :: *
  data ClientEnv = ClientEnv {manager :: http-client-0.7.17:Network.HTTP.Client.Types.Manager, baseUrl :: BaseUrl, cookieJar :: GHC.Maybe.Maybe (GHC.Conc.Sync.TVar http-client-0.7.17:Network.HTTP.Client.Types.CookieJar), makeClientRequest :: BaseUrl -> Servant.Client.Core.Request.Request -> GHC.Types.IO http-client-0.7.17:Network.HTTP.Client.Types.Request}
  type ClientError :: *
  data ClientError = FailureResponse (Servant.Client.Core.Request.RequestF () (BaseUrl, bytestring-0.11.5.3:Data.ByteString.Internal.Type.ByteString)) Response | DecodeFailure Data.Text.Internal.Text Response | UnsupportedContentType http-media-0.8.1.1:Network.HTTP.Media.MediaType.Internal.MediaType Response | InvalidContentTypeHeader Response | ConnectionError GHC.Exception.Type.SomeException
  type role ClientM nominal
  type ClientM :: * -> *
  newtype ClientM a = Servant.Client.Internal.HttpClient.ClientM {Servant.Client.Internal.HttpClient.unClientM :: Control.Monad.Trans.Reader.ReaderT ClientEnv (Control.Monad.Trans.Except.ExceptT ClientError GHC.Types.IO) a}
  type EmptyClient :: *
  data EmptyClient = EmptyClient
  type HasClient :: (* -> *) -> * -> Constraint
  class Servant.Client.Core.RunClient.RunClient m => HasClient m api where
    type Client :: (* -> *) -> * -> *
    type family Client m api
    clientWithRoute :: Data.Proxy.Proxy m -> Data.Proxy.Proxy api -> Servant.Client.Core.Request.Request -> Client m api
    hoistClientMonad :: forall (mon :: * -> *) (mon' :: * -> *). Data.Proxy.Proxy m -> Data.Proxy.Proxy api -> (forall x. mon x -> mon' x) -> Client mon api -> Client mon' api
    {-# MINIMAL clientWithRoute, hoistClientMonad #-}
    {-# MINIMAL clientWithRoute, hoistClientMonad #-}
  type InvalidBaseUrlException :: *
  newtype InvalidBaseUrlException = Servant.Client.Core.BaseUrl.InvalidBaseUrlException GHC.Base.String
  type Response :: *
  type Response = ResponseF Data.ByteString.Lazy.Internal.ByteString
  type ResponseF :: * -> *
  data ResponseF a = Response {responseStatusCode :: Network.HTTP.Types.Status.Status, responseHeaders :: Data.Sequence.Internal.Seq Network.HTTP.Types.Header.Header, responseHttpVersion :: Network.HTTP.Types.Version.HttpVersion, responseBody :: a}
  type Scheme :: *
  data Scheme = Http | Https
  type StreamingResponse :: *
  type StreamingResponse = ResponseF (Servant.API.Stream.SourceIO bytestring-0.11.5.3:Data.ByteString.Internal.Type.ByteString)
  client :: forall api. HasClient ClientM api => Data.Proxy.Proxy api -> Client ClientM api
  defaultMakeClientRequest :: BaseUrl -> Servant.Client.Core.Request.Request -> GHC.Types.IO http-client-0.7.17:Network.HTTP.Client.Types.Request
  foldMapUnion :: forall (c :: * -> Constraint) a (as :: [*]). Data.SOP.Constraint.All c as => Data.Proxy.Proxy c -> (forall x. c x => x -> a) -> Servant.API.UVerb.Union.Union as -> a
  hoistClient :: forall api (m :: * -> *) (n :: * -> *). HasClient ClientM api => Data.Proxy.Proxy api -> (forall a. m a -> n a) -> Client m api -> Client n api
  matchUnion :: forall a (as :: [*]). Servant.API.UVerb.Union.IsMember a as => Servant.API.UVerb.Union.Union as -> GHC.Maybe.Maybe a
  mkClientEnv :: http-client-0.7.17:Network.HTTP.Client.Types.Manager -> BaseUrl -> ClientEnv
  parseBaseUrl :: forall (m :: * -> *). Control.Monad.Catch.MonadThrow m => GHC.Base.String -> m BaseUrl
  runClientM :: forall a. ClientM a -> ClientEnv -> GHC.Types.IO (Data.Either.Either ClientError a)
  showBaseUrl :: BaseUrl -> GHC.Base.String

module Servant.Client.Internal.HttpClient where
  type ClientEnv :: *
  data ClientEnv = ClientEnv {manager :: http-client-0.7.17:Network.HTTP.Client.Types.Manager, baseUrl :: Servant.Client.Core.BaseUrl.BaseUrl, cookieJar :: GHC.Maybe.Maybe (GHC.Conc.Sync.TVar http-client-0.7.17:Network.HTTP.Client.Types.CookieJar), makeClientRequest :: Servant.Client.Core.BaseUrl.BaseUrl -> Servant.Client.Core.Request.Request -> GHC.Types.IO http-client-0.7.17:Network.HTTP.Client.Types.Request}
  type role ClientM nominal
  type ClientM :: * -> *
  newtype ClientM a = ClientM {unClientM :: Control.Monad.Trans.Reader.ReaderT ClientEnv (Control.Monad.Trans.Except.ExceptT Servant.Client.Core.ClientError.ClientError GHC.Types.IO) a}
  catchConnectionError :: forall a. GHC.Types.IO a -> GHC.Types.IO (Data.Either.Either Servant.Client.Core.ClientError.ClientError a)
  client :: forall api. Servant.Client.Core.HasClient.HasClient ClientM api => Data.Proxy.Proxy api -> Servant.Client.Core.HasClient.Client ClientM api
  clientResponseToResponse :: forall a b. (a -> b) -> http-client-0.7.17:Network.HTTP.Client.Types.Response a -> Servant.Client.Core.Response.ResponseF b
  defaultMakeClientRequest :: Servant.Client.Core.BaseUrl.BaseUrl -> Servant.Client.Core.Request.Request -> GHC.Types.IO http-client-0.7.17:Network.HTTP.Client.Types.Request
  hoistClient :: forall api (m :: * -> *) (n :: * -> *). Servant.Client.Core.HasClient.HasClient ClientM api => Data.Proxy.Proxy api -> (forall a. m a -> n a) -> Servant.Client.Core.HasClient.Client m api -> Servant.Client.Core.HasClient.Client n api
  mkClientEnv :: http-client-0.7.17:Network.HTTP.Client.Types.Manager -> Servant.Client.Core.BaseUrl.BaseUrl -> ClientEnv
  mkFailureResponse :: Servant.Client.Core.BaseUrl.BaseUrl -> Servant.Client.Core.Request.Request -> Servant.Client.Core.Response.ResponseF Data.ByteString.Lazy.Internal.ByteString -> Servant.Client.Core.ClientError.ClientError
  performRequest :: GHC.Maybe.Maybe [Network.HTTP.Types.Status.Status] -> Servant.Client.Core.Request.Request -> ClientM Servant.Client.Core.Response.Response
  runClientM :: forall a. ClientM a -> ClientEnv -> GHC.Types.IO (Data.Either.Either Servant.Client.Core.ClientError.ClientError a)

module Servant.Client.Internal.HttpClient.Streaming where
  type ClientEnv :: *
  data ClientEnv = ClientEnv {manager :: http-client-0.7.17:Network.HTTP.Client.Types.Manager, baseUrl :: Servant.Client.Core.BaseUrl.BaseUrl, cookieJar :: GHC.Maybe.Maybe (GHC.Conc.Sync.TVar http-client-0.7.17:Network.HTTP.Client.Types.CookieJar), makeClientRequest :: Servant.Client.Core.BaseUrl.BaseUrl -> Servant.Client.Core.Request.Request -> GHC.Types.IO http-client-0.7.17:Network.HTTP.Client.Types.Request}
  type role ClientM nominal
  type ClientM :: * -> *
  newtype ClientM a = ClientM {unClientM :: Control.Monad.Trans.Reader.ReaderT ClientEnv (Control.Monad.Trans.Except.ExceptT Servant.Client.Core.ClientError.ClientError (Control.Monad.Codensity.Codensity GHC.Types.IO)) a}
  catchConnectionError :: forall a. GHC.Types.IO a -> GHC.Types.IO (Data.Either.Either Servant.Client.Core.ClientError.ClientError a)
  client :: forall api. Servant.Client.Core.HasClient.HasClient ClientM api => Data.Proxy.Proxy api -> Servant.Client.Core.HasClient.Client ClientM api
  clientResponseToResponse :: forall a b. (a -> b) -> http-client-0.7.17:Network.HTTP.Client.Types.Response a -> Servant.Client.Core.Response.ResponseF b
  defaultMakeClientRequest :: Servant.Client.Core.BaseUrl.BaseUrl -> Servant.Client.Core.Request.Request -> GHC.Types.IO http-client-0.7.17:Network.HTTP.Client.Types.Request
  hoistClient :: forall api (m :: * -> *) (n :: * -> *). Servant.Client.Core.HasClient.HasClient ClientM api => Data.Proxy.Proxy api -> (forall a. m a -> n a) -> Servant.Client.Core.HasClient.Client m api -> Servant.Client.Core.HasClient.Client n api
  mkClientEnv :: http-client-0.7.17:Network.HTTP.Client.Types.Manager -> Servant.Client.Core.BaseUrl.BaseUrl -> ClientEnv
  performRequest :: GHC.Maybe.Maybe [Network.HTTP.Types.Status.Status] -> Servant.Client.Core.Request.Request -> ClientM Servant.Client.Core.Response.Response
  performWithStreamingRequest :: forall a. Servant.Client.Core.Request.Request -> (Servant.Client.Core.Response.StreamingResponse -> GHC.Types.IO a) -> ClientM a
  runClientM :: forall a. Control.DeepSeq.NFData a => ClientM a -> ClientEnv -> GHC.Types.IO (Data.Either.Either Servant.Client.Core.ClientError.ClientError a)
  withClientM :: forall a b. ClientM a -> ClientEnv -> (Data.Either.Either Servant.Client.Core.ClientError.ClientError a -> GHC.Types.IO b) -> GHC.Types.IO b

module Servant.Client.Streaming where
  (//) :: forall a b. a -> (a -> b) -> b
  (/:) :: forall a b c. (a -> b -> c) -> b -> a -> c
  type role AsClientT phantom
  type AsClientT :: (* -> *) -> *
  data AsClientT m
  type BaseUrl :: *
  data BaseUrl = BaseUrl {baseUrlScheme :: Scheme, baseUrlHost :: GHC.Base.String, baseUrlPort :: GHC.Types.Int, baseUrlPath :: GHC.Base.String}
  type ClientEnv :: *
  data ClientEnv = ClientEnv {manager :: http-client-0.7.17:Network.HTTP.Client.Types.Manager, baseUrl :: BaseUrl, cookieJar :: GHC.Maybe.Maybe (GHC.Conc.Sync.TVar http-client-0.7.17:Network.HTTP.Client.Types.CookieJar), makeClientRequest :: BaseUrl -> Servant.Client.Core.Request.Request -> GHC.Types.IO http-client-0.7.17:Network.HTTP.Client.Types.Request}
  type ClientError :: *
  data ClientError = FailureResponse (Servant.Client.Core.Request.RequestF () (BaseUrl, bytestring-0.11.5.3:Data.ByteString.Internal.Type.ByteString)) Response | DecodeFailure Data.Text.Internal.Text Response | UnsupportedContentType http-media-0.8.1.1:Network.HTTP.Media.MediaType.Internal.MediaType Response | InvalidContentTypeHeader Response | ConnectionError GHC.Exception.Type.SomeException
  type role ClientM nominal
  type ClientM :: * -> *
  newtype ClientM a = Servant.Client.Internal.HttpClient.Streaming.ClientM {Servant.Client.Internal.HttpClient.Streaming.unClientM :: Control.Monad.Trans.Reader.ReaderT ClientEnv (Control.Monad.Trans.Except.ExceptT ClientError (Control.Monad.Codensity.Codensity GHC.Types.IO)) a}
  type EmptyClient :: *
  data EmptyClient = EmptyClient
  type HasClient :: (* -> *) -> * -> Constraint
  class Servant.Client.Core.RunClient.RunClient m => HasClient m api where
    type Client :: (* -> *) -> * -> *
    type family Client m api
    clientWithRoute :: Data.Proxy.Proxy m -> Data.Proxy.Proxy api -> Servant.Client.Core.Request.Request -> Client m api
    hoistClientMonad :: forall (mon :: * -> *) (mon' :: * -> *). Data.Proxy.Proxy m -> Data.Proxy.Proxy api -> (forall x. mon x -> mon' x) -> Client mon api -> Client mon' api
    {-# MINIMAL clientWithRoute, hoistClientMonad #-}
    {-# MINIMAL clientWithRoute, hoistClientMonad #-}
  type InvalidBaseUrlException :: *
  newtype InvalidBaseUrlException = Servant.Client.Core.BaseUrl.InvalidBaseUrlException GHC.Base.String
  type Response :: *
  type Response = ResponseF Data.ByteString.Lazy.Internal.ByteString
  type ResponseF :: * -> *
  data ResponseF a = Response {responseStatusCode :: Network.HTTP.Types.Status.Status, responseHeaders :: Data.Sequence.Internal.Seq Network.HTTP.Types.Header.Header, responseHttpVersion :: Network.HTTP.Types.Version.HttpVersion, responseBody :: a}
  type Scheme :: *
  data Scheme = Http | Https
  type StreamingResponse :: *
  type StreamingResponse = ResponseF (Servant.API.Stream.SourceIO bytestring-0.11.5.3:Data.ByteString.Internal.Type.ByteString)
  client :: forall api. HasClient ClientM api => Data.Proxy.Proxy api -> Client ClientM api
  defaultMakeClientRequest :: BaseUrl -> Servant.Client.Core.Request.Request -> GHC.Types.IO http-client-0.7.17:Network.HTTP.Client.Types.Request
  foldMapUnion :: forall (c :: * -> Constraint) a (as :: [*]). Data.SOP.Constraint.All c as => Data.Proxy.Proxy c -> (forall x. c x => x -> a) -> Servant.API.UVerb.Union.Union as -> a
  hoistClient :: forall api (m :: * -> *) (n :: * -> *). HasClient ClientM api => Data.Proxy.Proxy api -> (forall a. m a -> n a) -> Client m api -> Client n api
  matchUnion :: forall a (as :: [*]). Servant.API.UVerb.Union.IsMember a as => Servant.API.UVerb.Union.Union as -> GHC.Maybe.Maybe a
  mkClientEnv :: http-client-0.7.17:Network.HTTP.Client.Types.Manager -> BaseUrl -> ClientEnv
  parseBaseUrl :: forall (m :: * -> *). Control.Monad.Catch.MonadThrow m => GHC.Base.String -> m BaseUrl
  runClientM :: forall a. Control.DeepSeq.NFData a => ClientM a -> ClientEnv -> GHC.Types.IO (Data.Either.Either ClientError a)
  showBaseUrl :: BaseUrl -> GHC.Base.String
  withClientM :: forall a b. ClientM a -> ClientEnv -> (Data.Either.Either ClientError a -> GHC.Types.IO b) -> GHC.Types.IO b


-- Instances:
instance aeson-2.2.3.0:Data.Aeson.Types.FromJSON.FromJSON Servant.Client.Core.BaseUrl.BaseUrl -- Defined in ‘Servant.Client.Core.BaseUrl’
instance aeson-2.2.3.0:Data.Aeson.Types.FromJSON.FromJSONKey Servant.Client.Core.BaseUrl.BaseUrl -- Defined in ‘Servant.Client.Core.BaseUrl’
instance aeson-2.2.3.0:Data.Aeson.Types.ToJSON.ToJSON Servant.Client.Core.BaseUrl.BaseUrl -- Defined in ‘Servant.Client.Core.BaseUrl’
instance aeson-2.2.3.0:Data.Aeson.Types.ToJSON.ToJSONKey Servant.Client.Core.BaseUrl.BaseUrl -- Defined in ‘Servant.Client.Core.BaseUrl’
instance Control.Monad.IO.Class.MonadIO Servant.Client.Internal.HttpClient.ClientM -- Defined in ‘Servant.Client.Internal.HttpClient’
instance Control.Monad.IO.Class.MonadIO Servant.Client.Internal.HttpClient.Streaming.ClientM -- Defined in ‘Servant.Client.Internal.HttpClient.Streaming’
instance Data.Data.Data Servant.Client.Core.BaseUrl.BaseUrl -- Defined in ‘Servant.Client.Core.BaseUrl’
instance Data.Data.Data Servant.Client.Core.BaseUrl.Scheme -- Defined in ‘Servant.Client.Core.BaseUrl’
instance Data.Foldable.Foldable Servant.Client.Core.Response.ResponseF -- Defined in ‘Servant.Client.Core.Response’
instance Data.Traversable.Traversable Servant.Client.Core.Response.ResponseF -- Defined in ‘Servant.Client.Core.Response’
instance GHC.Base.Applicative Servant.Client.Internal.HttpClient.ClientM -- Defined in ‘Servant.Client.Internal.HttpClient’
instance GHC.Base.Applicative Servant.Client.Internal.HttpClient.Streaming.ClientM -- Defined in ‘Servant.Client.Internal.HttpClient.Streaming’
instance GHC.Base.Functor Servant.Client.Internal.HttpClient.ClientM -- Defined in ‘Servant.Client.Internal.HttpClient’
instance GHC.Base.Functor Servant.Client.Core.Response.ResponseF -- Defined in ‘Servant.Client.Core.Response’
instance GHC.Base.Functor Servant.Client.Internal.HttpClient.Streaming.ClientM -- Defined in ‘Servant.Client.Internal.HttpClient.Streaming’
instance GHC.Base.Monad Servant.Client.Internal.HttpClient.ClientM -- Defined in ‘Servant.Client.Internal.HttpClient’
instance GHC.Base.Monad Servant.Client.Internal.HttpClient.Streaming.ClientM -- Defined in ‘Servant.Client.Internal.HttpClient.Streaming’
instance GHC.Enum.Bounded Servant.Client.Core.HasClient.EmptyClient -- Defined in ‘Servant.Client.Core.HasClient’
instance GHC.Enum.Enum Servant.Client.Core.HasClient.EmptyClient -- Defined in ‘Servant.Client.Core.HasClient’
instance GHC.Exception.Type.Exception Servant.Client.Core.BaseUrl.InvalidBaseUrlException -- Defined in ‘Servant.Client.Core.BaseUrl’
instance GHC.Exception.Type.Exception Servant.Client.Core.ClientError.ClientError -- Defined in ‘Servant.Client.Core.ClientError’
instance GHC.Generics.Generic Servant.Client.Core.BaseUrl.BaseUrl -- Defined in ‘Servant.Client.Core.BaseUrl’
instance GHC.Generics.Generic Servant.Client.Core.BaseUrl.Scheme -- Defined in ‘Servant.Client.Core.BaseUrl’
instance forall a. GHC.Generics.Generic (Servant.Client.Internal.HttpClient.ClientM a) -- Defined in ‘Servant.Client.Internal.HttpClient’
instance GHC.Generics.Generic Servant.Client.Core.ClientError.ClientError -- Defined in ‘Servant.Client.Core.ClientError’
instance forall a. GHC.Generics.Generic (Servant.Client.Core.Response.ResponseF a) -- Defined in ‘Servant.Client.Core.Response’
instance forall a. GHC.Generics.Generic (Servant.Client.Internal.HttpClient.Streaming.ClientM a) -- Defined in ‘Servant.Client.Internal.HttpClient.Streaming’
instance GHC.Show.Show Servant.Client.Core.HasClient.ClientParseError -- Defined in ‘Servant.Client.Core.HasClient’
instance GHC.Show.Show Servant.Client.Core.HasClient.EmptyClient -- Defined in ‘Servant.Client.Core.HasClient’
instance GHC.Show.Show Servant.Client.Core.BaseUrl.BaseUrl -- Defined in ‘Servant.Client.Core.BaseUrl’
instance GHC.Show.Show Servant.Client.Core.BaseUrl.InvalidBaseUrlException -- Defined in ‘Servant.Client.Core.BaseUrl’
instance GHC.Show.Show Servant.Client.Core.BaseUrl.Scheme -- Defined in ‘Servant.Client.Core.BaseUrl’
instance GHC.Show.Show Servant.Client.Core.ClientError.ClientError -- Defined in ‘Servant.Client.Core.ClientError’
instance forall a. GHC.Show.Show a => GHC.Show.Show (Servant.Client.Core.Response.ResponseF a) -- Defined in ‘Servant.Client.Core.Response’
instance Control.DeepSeq.NFData Servant.Client.Core.BaseUrl.BaseUrl -- Defined in ‘Servant.Client.Core.BaseUrl’
instance Control.DeepSeq.NFData Servant.Client.Core.ClientError.ClientError -- Defined in ‘Servant.Client.Core.ClientError’
instance forall a. Control.DeepSeq.NFData a => Control.DeepSeq.NFData (Servant.Client.Core.Response.ResponseF a) -- Defined in ‘Servant.Client.Core.Response’
instance Control.Monad.Catch.MonadCatch Servant.Client.Internal.HttpClient.ClientM -- Defined in ‘Servant.Client.Internal.HttpClient’
instance Control.Monad.Catch.MonadMask Servant.Client.Internal.HttpClient.ClientM -- Defined in ‘Servant.Client.Internal.HttpClient’
instance Control.Monad.Catch.MonadThrow Servant.Client.Internal.HttpClient.ClientM -- Defined in ‘Servant.Client.Internal.HttpClient’
instance GHC.Classes.Eq Servant.Client.Core.HasClient.ClientParseError -- Defined in ‘Servant.Client.Core.HasClient’
instance GHC.Classes.Eq Servant.Client.Core.HasClient.EmptyClient -- Defined in ‘Servant.Client.Core.HasClient’
instance GHC.Classes.Eq Servant.Client.Core.BaseUrl.BaseUrl -- Defined in ‘Servant.Client.Core.BaseUrl’
instance GHC.Classes.Eq Servant.Client.Core.BaseUrl.Scheme -- Defined in ‘Servant.Client.Core.BaseUrl’
instance GHC.Classes.Eq Servant.Client.Core.ClientError.ClientError -- Defined in ‘Servant.Client.Core.ClientError’
instance forall a. GHC.Classes.Eq a => GHC.Classes.Eq (Servant.Client.Core.Response.ResponseF a) -- Defined in ‘Servant.Client.Core.Response’
instance GHC.Classes.Ord Servant.Client.Core.BaseUrl.BaseUrl -- Defined in ‘Servant.Client.Core.BaseUrl’
instance GHC.Classes.Ord Servant.Client.Core.BaseUrl.Scheme -- Defined in ‘Servant.Client.Core.BaseUrl’
instance Control.Monad.Trans.Control.MonadBaseControl GHC.Types.IO Servant.Client.Internal.HttpClient.ClientM -- Defined in ‘Servant.Client.Internal.HttpClient’
instance Control.Monad.Error.Class.MonadError Servant.Client.Core.ClientError.ClientError Servant.Client.Internal.HttpClient.ClientM -- Defined in ‘Servant.Client.Internal.HttpClient’
instance Control.Monad.Error.Class.MonadError Servant.Client.Core.ClientError.ClientError Servant.Client.Internal.HttpClient.Streaming.ClientM -- Defined in ‘Servant.Client.Internal.HttpClient.Streaming’
instance Control.Monad.Reader.Class.MonadReader Servant.Client.Internal.HttpClient.ClientEnv Servant.Client.Internal.HttpClient.ClientM -- Defined in ‘Servant.Client.Internal.HttpClient’
instance Control.Monad.Reader.Class.MonadReader Servant.Client.Internal.HttpClient.ClientEnv Servant.Client.Internal.HttpClient.Streaming.ClientM -- Defined in ‘Servant.Client.Internal.HttpClient.Streaming’
instance Data.Functor.Alt.Alt Servant.Client.Internal.HttpClient.ClientM -- Defined in ‘Servant.Client.Internal.HttpClient’
instance Data.Functor.Alt.Alt Servant.Client.Internal.HttpClient.Streaming.ClientM -- Defined in ‘Servant.Client.Internal.HttpClient.Streaming’
instance forall (m :: * -> *). Servant.API.Generic.GenericMode (Servant.Client.Core.HasClient.AsClientT m) -- Defined in ‘Servant.Client.Core.HasClient’
instance [overlapping] forall a (x :: a) (xs :: [a]). Servant.API.UVerb.Union.UElem x (x : xs) -- Defined in ‘Servant.API.UVerb.Union’
instance [overlapping] forall a (x :: a) (xs :: [a]) (x' :: a). Servant.API.UVerb.Union.UElem x xs => Servant.API.UVerb.Union.UElem x (x' : xs) -- Defined in ‘Servant.API.UVerb.Union’
instance forall (api :: * -> *) (m :: * -> *). Servant.Client.Core.HasClient.GClientConstraints api m => Servant.Client.Core.HasClient.GClient api m -- Defined in ‘Servant.Client.Core.HasClient’
instance forall (m :: * -> *) a b. (Servant.Client.Core.HasClient.HasClient m a, Servant.Client.Core.HasClient.HasClient m b) => Servant.Client.Core.HasClient.HasClient m (a Servant.API.Alternative.:<|> b) -- Defined in ‘Servant.Client.Core.HasClient’
instance forall (path :: GHC.Types.Symbol) (m :: * -> *) api. (GHC.TypeLits.KnownSymbol path, Servant.Client.Core.HasClient.HasClient m api) => Servant.Client.Core.HasClient.HasClient m (path Servant.API.Sub.:> api) -- Defined in ‘Servant.Client.Core.HasClient’
instance [overlappable] forall k (m :: * -> *) (ty :: k) sub. (Servant.Client.Core.RunClient.RunClient m, (TypeError ...)) => Servant.Client.Core.HasClient.HasClient m (ty Servant.API.Sub.:> sub) -- Defined in ‘Servant.Client.Core.HasClient’
instance forall (m :: * -> *). Servant.Client.Core.RunClient.RunClient m => Servant.Client.Core.HasClient.HasClient m Servant.API.Empty.EmptyAPI -- Defined in ‘Servant.Client.Core.HasClient’
instance forall (api :: * -> *) (m :: * -> *). (forall (n :: * -> *). Servant.Client.Core.HasClient.GClient api n, Servant.Client.Core.HasClient.HasClient m (Servant.API.Generic.ToServantApi api), Servant.Client.Core.RunClient.RunClient m, Servant.API.TypeErrors.ErrorIfNoGeneric api) => Servant.Client.Core.HasClient.HasClient m (Servant.API.NamedRoutes.NamedRoutes api) -- Defined in ‘Servant.Client.Core.HasClient’
instance forall k1 (m :: * -> *) (method :: k1). (Servant.Client.Core.RunClient.RunClient m, Servant.API.Verbs.ReflectMethod method) => Servant.Client.Core.HasClient.HasClient m (Servant.API.Verbs.NoContentVerb method) -- Defined in ‘Servant.Client.Core.HasClient’
instance forall (m :: * -> *). Servant.Client.Core.RunClient.RunClient m => Servant.Client.Core.HasClient.HasClient m Servant.API.Raw.Raw -- Defined in ‘Servant.Client.Core.HasClient’
instance forall (m :: * -> *). Servant.Client.Core.RunClient.RunClient m => Servant.Client.Core.HasClient.HasClient m Servant.API.Raw.RawM -- Defined in ‘Servant.Client.Core.HasClient’
instance [overlappable] forall k1 (m :: * -> *) ct chunk (method :: k1) framing a (status :: GHC.TypeNats.Nat). (Servant.Client.Core.RunClient.RunStreamingClient m, Servant.API.ContentTypes.MimeUnrender ct chunk, Servant.API.Verbs.ReflectMethod method, Servant.API.Stream.FramingUnrender framing, Servant.API.Stream.FromSourceIO chunk a) => Servant.Client.Core.HasClient.HasClient m (Servant.API.Stream.Stream method status framing ct a) -- Defined in ‘Servant.Client.Core.HasClient’
instance [overlapping] forall k1 (m :: * -> *) ct chunk (method :: k1) framing a (hs :: [*]) (status :: GHC.TypeNats.Nat). (Servant.Client.Core.RunClient.RunStreamingClient m, Servant.API.ContentTypes.MimeUnrender ct chunk, Servant.API.Verbs.ReflectMethod method, Servant.API.Stream.FramingUnrender framing, Servant.API.Stream.FromSourceIO chunk a, Servant.API.ResponseHeaders.BuildHeadersTo hs) => Servant.Client.Core.HasClient.HasClient m (Servant.API.Stream.Stream method status framing ct (Servant.API.ResponseHeaders.Headers hs a)) -- Defined in ‘Servant.Client.Core.HasClient’
instance [overlapping] forall (m :: * -> *) (contentTypes :: [*]) contentType (otherContentTypes :: [*]) (as :: [*]) a (as' :: [*]) (method :: Network.HTTP.Types.Method.StdMethod).
                       (Servant.Client.Core.RunClient.RunClient m, contentTypes ~ (contentType : otherContentTypes), as ~ (a : as'), Servant.API.ContentTypes.AllMime contentTypes, Servant.API.Verbs.ReflectMethod method, Data.SOP.Constraint.All (Servant.Client.Core.HasClient.UnrenderResponse contentTypes) as, Data.SOP.Constraint.All Servant.API.UVerb.HasStatus as, Servant.API.UVerb.HasStatuses as', Servant.API.UVerb.Union.Unique (Servant.API.UVerb.Statuses as)) =>
                       Servant.Client.Core.HasClient.HasClient m (Servant.API.UVerb.UVerb method contentTypes as)
  -- Defined in ‘Servant.Client.Core.HasClient’
instance [overlappable] forall k1 (m :: * -> *) ct a (method :: k1) (cts' :: [*]) (cts :: [*]) (status :: GHC.TypeNats.Nat). (Servant.Client.Core.RunClient.RunClient m, Servant.API.ContentTypes.MimeUnrender ct a, Servant.API.Verbs.ReflectMethod method, cts' ~ (ct : cts), GHC.TypeNats.KnownNat status) => Servant.Client.Core.HasClient.HasClient m (Servant.API.Verbs.Verb method status cts' a) -- Defined in ‘Servant.Client.Core.HasClient’
instance [overlapping] forall k1 (m :: * -> *) (method :: k1) (status :: GHC.TypeNats.Nat) (cts :: [*]). (Servant.Client.Core.RunClient.RunClient m, Servant.API.Verbs.ReflectMethod method, GHC.TypeNats.KnownNat status) => Servant.Client.Core.HasClient.HasClient m (Servant.API.Verbs.Verb method status cts Servant.API.ContentTypes.NoContent) -- Defined in ‘Servant.Client.Core.HasClient’
instance [overlapping] forall k1 (m :: * -> *) ct a (ls :: [*]) (status :: GHC.TypeNats.Nat) (method :: k1) (cts' :: [*]) (cts :: [*]). (Servant.Client.Core.RunClient.RunClient m, Servant.API.ContentTypes.MimeUnrender ct a, Servant.API.ResponseHeaders.BuildHeadersTo ls, GHC.TypeNats.KnownNat status, Servant.API.Verbs.ReflectMethod method, cts' ~ (ct : cts)) => Servant.Client.Core.HasClient.HasClient m (Servant.API.Verbs.Verb method status cts' (Servant.API.ResponseHeaders.Headers ls a)) -- Defined in ‘Servant.Client.Core.HasClient’
instance [overlapping] forall k1 (m :: * -> *) (ls :: [*]) (method :: k1) (status :: GHC.TypeNats.Nat) (cts :: [*]). (Servant.Client.Core.RunClient.RunClient m, Servant.API.ResponseHeaders.BuildHeadersTo ls, Servant.API.Verbs.ReflectMethod method, GHC.TypeNats.KnownNat status) => Servant.Client.Core.HasClient.HasClient m (Servant.API.Verbs.Verb method status cts (Servant.API.ResponseHeaders.Headers ls Servant.API.ContentTypes.NoContent)) -- Defined in ‘Servant.Client.Core.HasClient’
instance forall (m :: * -> *) subapi (name :: GHC.Types.Symbol) (context :: [*]). Servant.Client.Core.HasClient.HasClient m subapi => Servant.Client.Core.HasClient.HasClient m (Servant.API.WithNamedContext.WithNamedContext name context subapi) -- Defined in ‘Servant.Client.Core.HasClient’
instance [overlappable] forall (m :: * -> *) api. (Servant.Client.Core.RunClient.RunClient m, (TypeError ...)) => Servant.Client.Core.HasClient.HasClient m api -- Defined in ‘Servant.Client.Core.HasClient’
instance [overlapping] forall (cts :: [*]) a (h :: [*]). (Servant.Client.Core.HasClient.UnrenderResponse cts a, Servant.API.ResponseHeaders.BuildHeadersTo h) => Servant.Client.Core.HasClient.UnrenderResponse cts (Servant.API.ResponseHeaders.Headers h a) -- Defined in ‘Servant.Client.Core.HasClient’
instance [overlapping] forall (cts :: [*]) a (n :: GHC.TypeNats.Nat). Servant.Client.Core.HasClient.UnrenderResponse cts a => Servant.Client.Core.HasClient.UnrenderResponse cts (Servant.API.UVerb.WithStatus n a) -- Defined in ‘Servant.Client.Core.HasClient’
instance [overlappable] forall (cts :: [*]) a. Servant.API.ContentTypes.AllMimeUnrender cts a => Servant.Client.Core.HasClient.UnrenderResponse cts a -- Defined in ‘Servant.Client.Core.HasClient’
instance Servant.Client.Core.RunClient.RunClient Servant.Client.Internal.HttpClient.ClientM -- Defined in ‘Servant.Client.Internal.HttpClient’
instance Servant.Client.Core.RunClient.RunClient Servant.Client.Internal.HttpClient.Streaming.ClientM -- Defined in ‘Servant.Client.Internal.HttpClient.Streaming’
instance Servant.Client.Core.RunClient.RunStreamingClient Servant.Client.Internal.HttpClient.Streaming.ClientM -- Defined in ‘Servant.Client.Internal.HttpClient.Streaming’
instance Language.Haskell.TH.Syntax.Lift Servant.Client.Core.BaseUrl.BaseUrl -- Defined in ‘Servant.Client.Core.BaseUrl’
instance Language.Haskell.TH.Syntax.Lift Servant.Client.Core.BaseUrl.Scheme -- Defined in ‘Servant.Client.Core.BaseUrl’
instance Control.Monad.Base.MonadBase GHC.Types.IO Servant.Client.Internal.HttpClient.ClientM -- Defined in ‘Servant.Client.Internal.HttpClient’
instance Control.Monad.Base.MonadBase GHC.Types.IO Servant.Client.Internal.HttpClient.Streaming.ClientM -- Defined in ‘Servant.Client.Internal.HttpClient.Streaming’
```

</details>

<details>
<summary>Diff</summary>


```diff
diff --git a/servant-client-api.txt b/servant-client-api.txt
index bb2d078..7bdf625 100644
--- a/servant-client-api.txt
+++ b/servant-client-api.txt
@@ -44,37 +44,14 @@ module Servant.Client where
   showBaseUrl :: BaseUrl -> GHC.Base.String
 
 module Servant.Client.Internal.HttpClient where
-  type ClientEnv :: *
-  data ClientEnv = ClientEnv {manager :: http-client-0.7.17:Network.HTTP.Client.Types.Manager, baseUrl :: Servant.Client.Core.BaseUrl.BaseUrl, cookieJar :: GHC.Maybe.Maybe (GHC.Conc.Sync.TVar http-client-0.7.17:Network.HTTP.Client.Types.CookieJar), makeClientRequest :: Servant.Client.Core.BaseUrl.BaseUrl -> Servant.Client.Core.Request.Request -> GHC.Types.IO http-client-0.7.17:Network.HTTP.Client.Types.Request}
-  type role ClientM nominal
-  type ClientM :: * -> *
-  newtype ClientM a = ClientM {unClientM :: Control.Monad.Trans.Reader.ReaderT ClientEnv (Control.Monad.Trans.Except.ExceptT Servant.Client.Core.ClientError.ClientError GHC.Types.IO) a}
-  catchConnectionError :: forall a. GHC.Types.IO a -> GHC.Types.IO (Data.Either.Either Servant.Client.Core.ClientError.ClientError a)
-  client :: forall api. Servant.Client.Core.HasClient.HasClient ClientM api => Data.Proxy.Proxy api -> Servant.Client.Core.HasClient.Client ClientM api
-  clientResponseToResponse :: forall a b. (a -> b) -> http-client-0.7.17:Network.HTTP.Client.Types.Response a -> Servant.Client.Core.Response.ResponseF b
-  defaultMakeClientRequest :: Servant.Client.Core.BaseUrl.BaseUrl -> Servant.Client.Core.Request.Request -> GHC.Types.IO http-client-0.7.17:Network.HTTP.Client.Types.Request
-  hoistClient :: forall api (m :: * -> *) (n :: * -> *). Servant.Client.Core.HasClient.HasClient ClientM api => Data.Proxy.Proxy api -> (forall a. m a -> n a) -> Servant.Client.Core.HasClient.Client m api -> Servant.Client.Core.HasClient.Client n api
-  mkClientEnv :: http-client-0.7.17:Network.HTTP.Client.Types.Manager -> Servant.Client.Core.BaseUrl.BaseUrl -> ClientEnv
-  mkFailureResponse :: Servant.Client.Core.BaseUrl.BaseUrl -> Servant.Client.Core.Request.Request -> Servant.Client.Core.Response.ResponseF Data.ByteString.Lazy.Internal.ByteString -> Servant.Client.Core.ClientError.ClientError
-  performRequest :: GHC.Maybe.Maybe [Network.HTTP.Types.Status.Status] -> Servant.Client.Core.Request.Request -> ClientM Servant.Client.Core.Response.Response
-  runClientM :: forall a. ClientM a -> ClientEnv -> GHC.Types.IO (Data.Either.Either Servant.Client.Core.ClientError.ClientError a)
+
+-- ignored
+
 
 module Servant.Client.Internal.HttpClient.Streaming where
-  type ClientEnv :: *
-  data ClientEnv = ClientEnv {manager :: http-client-0.7.17:Network.HTTP.Client.Types.Manager, baseUrl :: Servant.Client.Core.BaseUrl.BaseUrl, cookieJar :: GHC.Maybe.Maybe (GHC.Conc.Sync.TVar http-client-0.7.17:Network.HTTP.Client.Types.CookieJar), makeClientRequest :: Servant.Client.Core.BaseUrl.BaseUrl -> Servant.Client.Core.Request.Request -> GHC.Types.IO http-client-0.7.17:Network.HTTP.Client.Types.Request}
-  type role ClientM nominal
-  type ClientM :: * -> *
-  newtype ClientM a = ClientM {unClientM :: Control.Monad.Trans.Reader.ReaderT ClientEnv (Control.Monad.Trans.Except.ExceptT Servant.Client.Core.ClientError.ClientError (Control.Monad.Codensity.Codensity GHC.Types.IO)) a}
-  catchConnectionError :: forall a. GHC.Types.IO a -> GHC.Types.IO (Data.Either.Either Servant.Client.Core.ClientError.ClientError a)
-  client :: forall api. Servant.Client.Core.HasClient.HasClient ClientM api => Data.Proxy.Proxy api -> Servant.Client.Core.HasClient.Client ClientM api
-  clientResponseToResponse :: forall a b. (a -> b) -> http-client-0.7.17:Network.HTTP.Client.Types.Response a -> Servant.Client.Core.Response.ResponseF b
-  defaultMakeClientRequest :: Servant.Client.Core.BaseUrl.BaseUrl -> Servant.Client.Core.Request.Request -> GHC.Types.IO http-client-0.7.17:Network.HTTP.Client.Types.Request
-  hoistClient :: forall api (m :: * -> *) (n :: * -> *). Servant.Client.Core.HasClient.HasClient ClientM api => Data.Proxy.Proxy api -> (forall a. m a -> n a) -> Servant.Client.Core.HasClient.Client m api -> Servant.Client.Core.HasClient.Client n api
-  mkClientEnv :: http-client-0.7.17:Network.HTTP.Client.Types.Manager -> Servant.Client.Core.BaseUrl.BaseUrl -> ClientEnv
-  performRequest :: GHC.Maybe.Maybe [Network.HTTP.Types.Status.Status] -> Servant.Client.Core.Request.Request -> ClientM Servant.Client.Core.Response.Response
-  performWithStreamingRequest :: forall a. Servant.Client.Core.Request.Request -> (Servant.Client.Core.Response.StreamingResponse -> GHC.Types.IO a) -> ClientM a
-  runClientM :: forall a. Control.DeepSeq.NFData a => ClientM a -> ClientEnv -> GHC.Types.IO (Data.Either.Either Servant.Client.Core.ClientError.ClientError a)
-  withClientM :: forall a b. ClientM a -> ClientEnv -> (Data.Either.Either Servant.Client.Core.ClientError.ClientError a -> GHC.Types.IO b) -> GHC.Types.IO b
+
+-- ignored
+
 
 module Servant.Client.Streaming where
   (//) :: forall a b. a -> (a -> b) -> b

```

</details>