### PR TITLE
Haddock attributes of a module to determine the visibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
     branches: ['main']
 
 jobs:
+
   generate-matrix:
     name: 'Generate matrix from cabal'
     outputs:
@@ -184,6 +185,7 @@ jobs:
           done
           echo "$GITHUB_WORKSPACE/distribution" >> "$GITHUB_PATH"
           echo "REPORT_NAME=report-${{ env.KERNEL }}-static-ghc-${{ matrix.ghc }}" >> $GITHUB_ENV
+          echo "$GITHUB_WORKSPACE/distribution" >> "$GITHUB_PATH"
 
       - name: Test
         run: cabal test --project-file=cabal.static.project --test-options "--xml=../print-api/${REPORT_NAME}.xml" all

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,6 +93,17 @@ jobs:
         if: success() || failure() # always run even if the previous step fails
         with:
           report_paths: "report.xml"
+          cp ${bin} distribution/print-api
+          echo "$GITHUB_WORKSPACE/distribution" >> "$GITHUB_PATH"
+
+      - name: Test
+        run: cabal test --project-file=cabal.static.project --test-options "--xml=../print-api/report.xml" all
+
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@v4
+        if: success() || failure() # always run even if the previous step fails
+        with:
+          report_paths: "report.xml"
 
       - name: File type
         run: file distribution/*
@@ -177,6 +188,17 @@ jobs:
 
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v5
+        if: success() || failure() # always run even if the previous step fails
+        with:
+          report_paths: "report.xml"
+          cp ${bin} distribution/print-api
+          echo "$GITHUB_WORKSPACE/distribution" >> "$GITHUB_PATH"
+
+      - name: Test
+        run: cabal test --project-file=cabal.static.project --test-options "--xml=../print-api/report.xml" all
+
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@v4
         if: success() || failure() # always run even if the previous step fails
         with:
           report_paths: "report.xml"

--- a/app/print-api/Main.hs
+++ b/app/print-api/Main.hs
@@ -1,8 +1,14 @@
+{-# LANGUAGE CPP #-}
+
 module Main where
 
+import Data.ByteString.Lazy.Char8 qualified as ByteString
+import Data.List.Extra qualified as List
 import Options.Applicative
+import PrintApi.Utils
 import System.IO
 
+import PrintApi.CLI.Cmd.Dump (run)
 import PrintApi.CLI.Types
 
 main :: IO ()
@@ -10,3 +16,10 @@ main = do
   hSetBuffering stdout LineBuffering
   parseResult <- execParser (parseOptions `withInfo` "Export the declarations of a Haskell package")
   runOptions parseResult
+
+runOptions
+  :: Options
+  -> IO ()
+runOptions (Options packageName mIgnoreList usePublicOnly) = do
+  stdOut <- readCabalizedProcess (Just TOOL_VERSION_ghc) "ghc" ["--print-libdir"]
+  run (List.trimEnd $ ByteString.unpack stdOut) mIgnoreList usePublicOnly packageName

--- a/cabal.project
+++ b/cabal.project
@@ -4,6 +4,11 @@ tests: True
 
 write-ghc-environment-files: always
 
+package print-api
+  ghc-options: -haddock
+
+documentation: True
+
 allow-newer:
     tasty-test-reporter:mtl
   , tasty-test-reporter:ansi-terminal

--- a/compat/9.8.2/GHC/Compat.hs
+++ b/compat/9.8.2/GHC/Compat.hs
@@ -3,7 +3,7 @@ module GHC.Compat where
 
 import GHC (ModuleInfo)
 import GHC.Iface.Syntax (AltPpr (..), ShowForAllFlag (..), ShowHowMuch (..), ShowSub (..))
-import PrintApi.IgnoredDeclarations
+import PrintApi.IgnoredDeclarations ()
 
 mkShowSub :: ModuleInfo -> ShowSub
 mkShowSub _ =

--- a/print-api.cabal
+++ b/print-api.cabal
@@ -1,5 +1,6 @@
 cabal-version:      2.4
 name:               print-api
+
 -- For the purpose of release and pre-release versioning, we use the following scheme:
 -- EPOCH.MAJOR.MINOR.PATCH
 -- with the MINOR member being even for releases and odd for pre-releases
@@ -54,12 +55,14 @@ common print-api-common
   -- main-is:          Main.hs
   build-depends:
     , base
+    , bytestring
+    , extra
     , ghc
     , ghc-paths
     , optparse-applicative
     , print-api
 
-  default-language: Haskell2010
+  default-language: GHC2021
 
 library
   import:          extensions
@@ -89,11 +92,13 @@ library
   build-depends:
     , base
     , bytestring
+    , containers
     , extra
     , filepath
     , ghc
     , ghc-boot
     , ghc-paths
+    , haddock-library
     , optparse-applicative
     , process
     , text

--- a/test/IgnoreList.hs
+++ b/test/IgnoreList.hs
@@ -48,7 +48,7 @@ generateVectorAPIWithIgnoreList = do
   ignoreListFilePath <- liftIO $ OsPath.decodeUtf ignoreListPath
   modules <- lines <$> liftIO (System.readFile ignoreListFilePath)
   let ignoredModules = List.map mkModuleName modules
-  actualAPI <- liftIO $ Dump.computePackageAPI (List.trimEnd $ C8.unpack stdOut) ignoredModules "vector"
+  actualAPI <- liftIO $ Dump.computePackageAPI False (List.trimEnd $ C8.unpack stdOut) ignoredModules "vector"
   actualApiPath <- liftIO $ Directory.makeAbsolute "../print-api/test/golden/vector-actual-api.txt"
   liftIO $ System.writeFile actualApiPath actualAPI
   liftIO $ ByteString.readFile actualApiPath


### PR DESCRIPTION
This is an experiment to use Haddock attributes of a module's documentation to determine whether or not a public is part of a public or internal API.