### PR TITLE
Use full commit hash for tasty-test-reporter

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -27,4 +27,4 @@ allow-newer:
 source-repository-package
   type: git
   location: https://github.com/goodlyrottenapple/tasty-test-reporter 
-  tag: b704130
+  tag: b704130545aa3925a8487bd3e92f1dd5ce0512e2


### PR DESCRIPTION
It is better to use the full hash instead of an abbreviated one, isn't it (see https://github.com/haskell/cabal/issues/10605)?