### PR TITLE
Support GHC 9.12.1

### DIFF
--- a/compat/9.12.1/GHC/Compat.hs
+++ b/compat/9.12.1/GHC/Compat.hs
@@ -1,18 +1,14 @@
--- GHC 9.10.1 compatibility
+-- GHC 9.12.1 compatibility
 module GHC.Compat
-  ( mkNamePprCtxForModule
+  ( GHC.mkNamePprCtxForModule
   , mkShowSub
   ) where
 
-import Data.Maybe (fromJust)
-import GHC (Ghc, Module, ModuleInfo, NamePprCtx)
+import GHC (ModuleInfo)
 import GHC qualified
 import GHC.Iface.Syntax (AltPpr (..), ShowForAllFlag (..), ShowHowMuch (..), ShowSub (..))
 
 import PrintApi.IgnoredDeclarations
-
-mkNamePprCtxForModule :: Module -> ModuleInfo -> Ghc NamePprCtx
-mkNamePprCtxForModule _ mod_info = fromJust <$> GHC.mkNamePprCtxForModule mod_info
 
 mkShowSub :: ModuleInfo -> ShowSub
 mkShowSub mod_info =

--- a/compat/9.6.6/GHC/Compat.hs
+++ b/compat/9.6.6/GHC/Compat.hs
@@ -1,8 +1,16 @@
--- GHC 9.6.6 Compatibility
-module GHC.Compat where
+-- GHC 9.6.6 compatibility
+module GHC.Compat
+  ( mkNamePprCtxForModule
+  , mkShowSub
+  ) where
 
-import GHC (ModuleInfo)
+import Data.Maybe (fromJust)
+import GHC (Ghc, Module, ModuleInfo, NamePprCtx)
+import GHC qualified
 import GHC.Iface.Syntax (AltPpr (..), ShowForAllFlag (..), ShowHowMuch (..), ShowSub (..))
+
+mkNamePprCtxForModule :: Module -> ModuleInfo -> Ghc NamePprCtx
+mkNamePprCtxForModule _ mod_info = fromJust <$> GHC.mkNamePprCtxForModule mod_info
 
 mkShowSub :: ModuleInfo -> ShowSub
 mkShowSub _mod_info =

--- a/compat/9.8.4/GHC/Compat.hs
+++ b/compat/9.8.4/GHC/Compat.hs
@@ -1,9 +1,16 @@
--- GHC 9.10.1 Compatibility
-module GHC.Compat where
+-- GHC 9.8.4 compatibility
+module GHC.Compat
+  ( mkNamePprCtxForModule
+  , mkShowSub
+  ) where
 
-import GHC (ModuleInfo)
+import Data.Maybe (fromJust)
+import GHC (Ghc, Module, ModuleInfo, NamePprCtx)
+import GHC qualified
 import GHC.Iface.Syntax (AltPpr (..), ShowForAllFlag (..), ShowHowMuch (..), ShowSub (..))
-import PrintApi.IgnoredDeclarations ()
+
+mkNamePprCtxForModule :: Module -> ModuleInfo -> Ghc NamePprCtx
+mkNamePprCtxForModule _ mod_info = fromJust <$> GHC.mkNamePprCtxForModule mod_info
 
 mkShowSub :: ModuleInfo -> ShowSub
 mkShowSub _ =

--- a/print-api.cabal
+++ b/print-api.cabal
@@ -12,10 +12,11 @@ maintainer:         hecate+github@glitchbra.in
 copyright:          © 2023 Ben Gamari, 2024 Hécate Kleidukos
 extra-source-files:
   compat/9.10.1/GHC/Compat.hs
+  compat/9.12.1/GHC/Compat.hs
   compat/9.6.6/GHC/Compat.hs
   compat/9.8.4/GHC/Compat.hs
 
-tested-with:        GHC ==9.6.6 || ==9.8.4 || ==9.10.1
+tested-with:        GHC ==9.6.6 || ==9.8.4 || ==9.10.1 || ==9.12.1
 
 common extensions
   default-extensions:
@@ -69,14 +70,17 @@ library
   import:          ghc-options
   hs-source-dirs:  src
 
-  if impl(ghc ==9.10.1)
-    hs-source-dirs: compat/9.10.1
+  if impl(ghc ==9.6.6)
+    hs-source-dirs: compat/9.6.6
 
   if impl(ghc ==9.8.4)
     hs-source-dirs: compat/9.8.4
 
-  if impl(ghc ==9.6.6)
-    hs-source-dirs: compat/9.6.6
+  if impl(ghc ==9.10.1)
+    hs-source-dirs: compat/9.10.1
+
+  if impl(ghc ==9.12.1)
+    hs-source-dirs: compat/9.12.1
 
   other-modules:   Paths_print_api
   autogen-modules: Paths_print_api
@@ -143,6 +147,16 @@ executable print-api-9.10.1
   main-is: Main.hs
 
   if impl(ghc ==9.10.1)
+    buildable: True
+
+  else
+    buildable: False
+
+executable print-api-9.12.1
+  import:  print-api-common
+  main-is: Main.hs
+
+  if impl(ghc ==9.12.1)
     buildable: True
 
   else

--- a/src/PrintApi/CLI/Cmd/Dump.hs
+++ b/src/PrintApi/CLI/Cmd/Dump.hs
@@ -12,9 +12,9 @@
 --
 --  The processing of package information
 module PrintApi.CLI.Cmd.Dump
-    ( run
-    , computePackageAPI
-    ) where
+  ( run
+  , computePackageAPI
+  ) where
 
 import Control.Monad.IO.Class
 import Data.Function (on, (&))


### PR DESCRIPTION
Due to the changed type of `GHC.mkNamePprCtxForModule` (introduced in https://gitlab.haskell.org/ghc/ghc/-/commit/c5d89412dd21a428709c00499dfa611312ad4735) we need to add an own version of it in the compatibility layer.

I also added an explicit export list for `PrintApi.CLI.Cmd.Dump` such that only the functions needed by the executables are exported: The motivation for this is a more stable API of that module, and to hide changes to the internals like the changed type of the `extractModuleDeclarations` function. Please let me know if that is too restrictive.